### PR TITLE
Fix using pinned version of workspace deps workspace and bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "eclipse-cyclonedds"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "eclipse-cyclonedds-macros"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "eclipse-cyclonedds-sys"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "bindgen",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cyclonedds", "cyclonedds-sys", "cyclonedds-macros"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 homepage = "https://cyclonedds.io/"
 repository = "https://github.com/eclipse-cyclonedds/cyclonedds-rust"
@@ -12,8 +12,8 @@ authors = ["Troy Karan Harrison <troy.harrison@zettascale.tech>"]
 description = "Rust binding for Eclipse Cyclone DDS"
 
 [workspace.dependencies]
-eclipse-cyclonedds-sys = { version = "0.0.1", path = "cyclonedds-sys" }
-eclipse-cyclonedds-macros = { version = "0.0.1", path = "cyclonedds-macros" }
+eclipse-cyclonedds-sys = { path = "cyclonedds-sys" }
+eclipse-cyclonedds-macros = { path = "cyclonedds-macros" }
 
 [workspace.metadata.crane]
 name = "eclipse-cyclonedds"


### PR DESCRIPTION
The bump is also so the package can be re-published with the vendored version of the Cyclone DDS C library.