### PR TITLE
General housekeeping

### DIFF
--- a/.check-commits.yaml
+++ b/.check-commits.yaml
@@ -21,6 +21,8 @@ trailers:
     values:
       # keep-sorted start
       - cyclonedds
-      - cyclonedds-derive
+      - cyclonedds-macros
       - cyclonedds-sys
       # keep-sorted end
+      ## NOTE: renamed to `cyclonedds-macros`
+      - cyclonedds-derive

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -78,9 +78,6 @@ jobs:
       - name: run additional flake checks
         run: nix flake check
 
-      - name: run additional flake checks with submodules
-        run: nix flake check .?submodules=1
-
   check-macos:
     strategy:
       matrix:
@@ -142,9 +139,6 @@ jobs:
          
       - name: run additional flake checks
         run: nix flake check
-
-      - name: run additional flake checks with submodules
-        run: nix flake check .?submodules=1
 
   check-windows:
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "eclipse-cyclonedds"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "eclipse-cyclonedds-macros"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "eclipse-cyclonedds-sys"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "bindgen",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cyclonedds", "cyclonedds-sys", "cyclonedds-macros"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.2"
+version = "0.0.3"
 edition = "2024"
 homepage = "https://cyclonedds.io/"
 repository = "https://github.com/eclipse-cyclonedds/cyclonedds-rust"
@@ -12,8 +12,8 @@ authors = ["Troy Karan Harrison <troy.harrison@zettascale.tech>"]
 description = "Rust binding for Eclipse Cyclone DDS"
 
 [workspace.dependencies]
-eclipse-cyclonedds-sys = { version = "0.0.2", path = "cyclonedds-sys" }
-eclipse-cyclonedds-macros = { version = "0.0.2", path = "cyclonedds-macros" }
+eclipse-cyclonedds-sys = { version = "0.0.3", path = "cyclonedds-sys" }
+eclipse-cyclonedds-macros = { version = "0.0.3", path = "cyclonedds-macros" }
 
 [workspace.metadata.crane]
 name = "eclipse-cyclonedds"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The official Rust binding for [Eclipse Cyclone DDS][cyclonedds-github].
 - [Quick Start](#quick-start)
 - [Overview of DDS](#overview-of-dds)
 - [Example](#example)
+- [Common footguns](#common-footguns)
 
 ## Quick Start
 
@@ -117,8 +118,6 @@ See the [DDS Specification][dds-spec] and the [OMG DDS Wiki][omg-dds-wiki] for
 these other elements and see the [Rust Documentation][docs.rs] for what is
 supported by this API.
 
-<!-- TODO add details on the footguns (default QoS, read and take semantics) -->
-
 ## Example
 
 ```rust
@@ -202,6 +201,76 @@ fn main() -> cyclonedds::Result<()> {
     Ok(())
 }
 ```
+
+## Common footguns
+
+### QoS mismatch
+
+A `Writer` and `Reader` only exchange samples after discovery finds matching
+topic names, compatible type information, and compatible `QoS` policies. If
+samples are not arriving, check the effective `QoS` on both endpoints before
+assuming the network or serialization layer is at fault.
+
+### QoS offer/request asymmetry
+
+`QoS` compatibility follows an offer/request model: the writer offers a `QoS`
+and the reader requests one. Compatibility is asymmetric. A writer offering
+`Reliable` delivery is compatible with a reader requesting `BestEffort`, but not
+the inverse. The same asymmetry applies to `Durability`: a writer offering
+`TransientLocal` is compatible with a reader requesting `Volatile`, but a reader
+requesting `TransientLocal` will not match a writer offering only `Volatile`.
+
+### Durability and late-joining readers
+
+The default durability **does not** make DDS behave like a retained-message
+broker. A reader that joins after a writer has already published will not
+receive historical samples unless both sides are configured with compatible
+durability (`TransientLocal` or stronger) and sufficient history depth.
+`Volatile` durability, the default, discards samples the moment no matched
+reader exists to receive them.
+
+### Reliability and history depth
+
+Reliable delivery asks the middleware to retransmit missing samples, but does
+not provide infinite buffering. The default history policy is `KeepLast` with a
+depth of 1, so only the most recent sample is retained per writer instance.
+History depth, resource limits, and slow readers all constrain how much data the
+middleware retains. A writer paired with a slow reliable reader may block or
+drop samples once its send queue is exhausted, depending on the
+`max_blocking_time` and resource limit settings in effect.
+
+### Domain ID isolation
+
+Participants on different domain IDs are completely isolated. Discovery will not
+cross domain boundaries, so two nodes that are otherwise correctly configured
+will be invisible to each other if their domain IDs differ.
+
+### Partition mismatch
+
+Partitions introduce a second matching layer on top of topic name and `QoS`. A
+writer and reader on the same topic will not exchange samples unless they share
+at least one partition string note that the empty string `""` a valid and
+distinct partition.
+
+### Liveliness
+
+`Liveliness` configuration determines when the middleware considers a writer
+dead. If the lease duration is shorter than the writer's actual publish rate,
+the writer may appear to die and recover under load, causing spurious
+matched/unmatched transitions on the reader side.
+
+### `read` vs `take`
+
+`read` and `take` have different cache semantics. `read` leaves matching samples
+in the reader cache, so subsequent reads with overlapping state masks may return
+the same samples again. `take` removes them, making those samples unavailable to
+any later call. Use `take` for queue-like consumption and `read` when you need
+to inspect the current state without draining it.
+
+Cyclone DDS also includes a `peek` call which reads without updating any sample
+or view state, so repeated peeks always see the same samples regardless of state
+masks. Use it for non-destructive inspection when state transitions are
+undesirable.
 
 ## Minimum supported Rust version (MSRV)
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # Rust Binding for Eclipse Cyclone DDS
 
-[![License][epl-license-shield]][epl-license]
-[![License][edl-license-shield]][edl-license]
 [![Latest Version][crates.io-shield]][crates.io]
-[![Documentation][docs.rs-shield]][docs.rs]
 [![Build Status][check-workflow-status-shield]][check-workflow]
-[![Website][cyclonedds-homepage-shield]][cyclonedds-homepage]
-[![Dependency Status][deps.rs-shield]][deps.rs]
 [![Community][community-shield]][community]
+[![Website][cyclonedds-homepage-shield]][cyclonedds-homepage]
+
+[![Documentation][docs.rs-shield]][docs.rs]
+[![Dependency Status][deps.rs-shield]][deps.rs]
 
 The official Rust binding for [Eclipse Cyclone DDS][cyclonedds-github].
 
@@ -287,23 +286,19 @@ For now, the MSRV is the latest stable Rust version at the time of release.
 - [Security Policy](SECURITY.md)
 
 [check-workflow]: https://github.com/eclipse-cyclonedds/cyclonedds-rust/actions/workflows/check.yml
-[check-workflow-status-shield]: https://img.shields.io/github/actions/workflow/status/eclipse-cyclonedds/cyclonedds-rust/check.yml
+[check-workflow-status-shield]: https://shieldcn.dev/github/ci/eclipse-cyclonedds/cyclonedds-rust?no-track&mode=light&size=xs
 [community]: https://discord.gg/4QQvWZrFKF
-[community-shield]: https://img.shields.io/discord/960814229844291604.svg?logo=discord
+[community-shield]: https://shieldcn.dev/discord/960814229844291604.svg?no-track&variant=branded&size=xs
 [crates.io]: https://crates.io/crates/eclipse-cyclonedds
-[crates.io-shield]: https://img.shields.io/crates/v/eclipse-cyclonedds.svg
+[crates.io-shield]: https://shieldcn.dev/group/crates/eclipse-cyclonedds+crates/license/eclipse-cyclonedds.svg?no-track&mode=light&size=xs
 [cyclonedds-docs]: https://cyclonedds.io/docs
 [cyclonedds-github]: https://github.com/eclipse-cyclonedds/cyclonedds
 [cyclonedds-homepage]: https://cyclonedds.io
-[cyclonedds-homepage-shield]: https://img.shields.io/badge/web-cyclonedds.io-blue
+[cyclonedds-homepage-shield]: https://shieldcn.dev/badge/web-cyclonedds.io-blue.svg?no-track&mode=light&logo=lu%3ATornado&size=xs
 [dds-spec]: https://www.omg.org/spec/DDS/1.4/About-DDS/
 [ddsi-rtps-spec]: https://www.omg.org/spec/DDSI-RTPS/
 [deps.rs]: https://deps.rs/repo/github/eclipse-cyclonedds/cyclonedds-rust
 [deps.rs-shield]: https://deps.rs/repo/github/eclipse-cyclonedds/cyclonedds-rust/status.svg
 [docs.rs]: https://docs.rs/eclipse-cyclonedds
 [docs.rs-shield]: https://docs.rs/eclipse-cyclonedds/badge.svg
-[edl-license]: https://choosealicense.com/licenses/edl-1.0/
-[edl-license-shield]: https://img.shields.io/badge/license-EDL%201.0-blue
-[epl-license]: https://choosealicense.com/licenses/epl-2.0/
-[epl-license-shield]: https://img.shields.io/badge/license-EPL%202.0-blue
 [omg-dds-wiki]: https://www.omgwiki.org/ddsf/doku.php?id=ddsf:public:guidebook:01_front:4_toc

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ via the `vendored` feature. Then add the package to your `Cargo.toml` via:
 #
 # NOTE: you can also point to Cyclone DDS using the `CYCLONEDDS_HOME` variable if
 # performing a full installation is undesirable.
-eclipse-cyclonedds = "0.0.2"
+eclipse-cyclonedds = "0.0.3"
 
 # Using the `vendored` feature will result in us compiling and linking in a version
 # of Cyclone DDS for you.
-eclipse-cyclonedds = { version = "0.0.2", features = ["vendored"] }
+eclipse-cyclonedds = { version = "0.0.3", features = ["vendored"] }
 ```
 
 Then see [the example](#example) and [the docs][docs.rs] to get started.

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ via the `vendored` feature. Then add the package to your `Cargo.toml` via:
 #
 # NOTE: you can also point to Cyclone DDS using the `CYCLONEDDS_HOME` variable if
 # performing a full installation is undesirable.
-eclipse-cyclonedds = "0.0.1"
+eclipse-cyclonedds = "0.0.2"
 
 # Using the `vendored` feature will result in us compiling and linking in a version
 # of Cyclone DDS for you.
-eclipse-cyclonedds = { version = "0.0.1", features = ["vendored"] }
+eclipse-cyclonedds = { version = "0.0.2", features = ["vendored"] }
 ```
 
 Then see [the example](#example) and [the docs][docs.rs] to get started.

--- a/cyclonedds-macros/README.md
+++ b/cyclonedds-macros/README.md
@@ -37,7 +37,7 @@ For normal DDS applications, add the main binding:
 
 ```toml
 [dependencies]
-eclipse-cyclonedds = "0.0.2"
+eclipse-cyclonedds = "0.0.3"
 serde = { version = "1", features = ["derive"] }
 ```
 

--- a/cyclonedds-macros/README.md
+++ b/cyclonedds-macros/README.md
@@ -1,12 +1,12 @@
 # Procedural Macros for Eclipse Cyclone DDS
 
-[![License][epl-license-shield]][epl-license]
-[![License][edl-license-shield]][edl-license]
 [![Latest Version][crates.io-shield]][crates.io]
-[![Documentation][docs.rs-shield]][docs.rs]
 [![Build Status][check-workflow-status-shield]][check-workflow]
-[![Website][cyclonedds-homepage-shield]][cyclonedds-homepage]
 [![Community][community-shield]][community]
+[![Website][cyclonedds-homepage-shield]][cyclonedds-homepage]
+
+[![Documentation][docs.rs-shield]][docs.rs]
+[![Dependency Status][deps.rs-shield]][deps.rs]
 
 Procedural macros for the official Rust binding for
 [Eclipse Cyclone DDS][cyclonedds-github].
@@ -131,23 +131,21 @@ For now, the MSRV is the latest stable Rust version at the time of release.
 - [Security Policy](../SECURITY.md)
 
 [check-workflow]: https://github.com/eclipse-cyclonedds/cyclonedds-rust/actions/workflows/check.yml
-[check-workflow-status-shield]: https://img.shields.io/github/actions/workflow/status/eclipse-cyclonedds/cyclonedds-rust/check.yml
+[check-workflow-status-shield]: https://shieldcn.dev/github/ci/eclipse-cyclonedds/cyclonedds-rust?no-track&mode=light&size=xs
 [community]: https://discord.gg/4QQvWZrFKF
-[community-shield]: https://img.shields.io/discord/960814229844291604.svg?logo=discord
+[community-shield]: https://shieldcn.dev/discord/960814229844291604.svg?no-track&variant=branded&size=xs
 [crates.io]: https://crates.io/crates/eclipse-cyclonedds-macros
-[crates.io-shield]: https://img.shields.io/crates/v/eclipse-cyclonedds-macros.svg
+[crates.io-shield]: https://shieldcn.dev/group/crates/eclipse-cyclonedds-macros+crates/license/eclipse-cyclonedds-macros.svg?no-track&mode=light&size=xs
 [cyclonedds-docs]: https://cyclonedds.io/docs
 [cyclonedds-github]: https://github.com/eclipse-cyclonedds/cyclonedds
 [cyclonedds-homepage]: https://cyclonedds.io
-[cyclonedds-homepage-shield]: https://img.shields.io/badge/web-cyclonedds.io-blue
+[cyclonedds-homepage-shield]: https://shieldcn.dev/badge/web-cyclonedds.io-blue.svg?no-track&mode=light&logo=lu%3ATornado&size=xs
 [dds-spec]: https://www.omg.org/spec/DDS/1.4/About-DDS/
 [ddsi-rtps-spec]: https://www.omg.org/spec/DDSI-RTPS/
+[deps.rs]: https://deps.rs/repo/github/eclipse-cyclonedds/cyclonedds-rust
+[deps.rs-shield]: https://deps.rs/repo/github/eclipse-cyclonedds/cyclonedds-rust/status.svg
 [docs.rs]: https://docs.rs/eclipse-cyclonedds-macros
 [docs.rs-shield]: https://docs.rs/eclipse-cyclonedds-macros/badge.svg
 [eclipse-cyclonedds]: https://crates.io/crates/eclipse-cyclonedds
 [eclipse-cyclonedds-docs]: https://docs.rs/eclipse-cyclonedds
-[edl-license]: https://choosealicense.com/licenses/edl-1.0/
-[edl-license-shield]: https://img.shields.io/badge/license-EDL%201.0-blue
-[epl-license]: https://choosealicense.com/licenses/epl-2.0/
-[epl-license-shield]: https://img.shields.io/badge/license-EPL%202.0-blue
 [omg-dds-wiki]: https://www.omgwiki.org/ddsf/doku.php?id=ddsf:public:guidebook:01_front:4_toc

--- a/cyclonedds-macros/README.md
+++ b/cyclonedds-macros/README.md
@@ -1,1 +1,153 @@
-../README.md
+# Procedural Macros for Eclipse Cyclone DDS
+
+[![License][epl-license-shield]][epl-license]
+[![License][edl-license-shield]][edl-license]
+[![Latest Version][crates.io-shield]][crates.io]
+[![Documentation][docs.rs-shield]][docs.rs]
+[![Build Status][check-workflow-status-shield]][check-workflow]
+[![Website][cyclonedds-homepage-shield]][cyclonedds-homepage]
+[![Community][community-shield]][community]
+
+Procedural macros for the official Rust binding for
+[Eclipse Cyclone DDS][cyclonedds-github].
+
+This crate currently provides the `Topicable` derive macro used by
+[`eclipse-cyclonedds`][eclipse-cyclonedds]. Most users should depend on
+`eclipse-cyclonedds` and use its re-export:
+
+```rust
+#[derive(cyclonedds::Topicable, serde::Serialize, serde::Deserialize, Clone, Default, Debug)]
+struct Sensor {
+    #[dds(key)]
+    id: u32,
+    temperature: f32,
+}
+```
+
+Depend on `eclipse-cyclonedds-macros` directly only when you need the proc macro
+crate itself.
+
+- [Quick Start](#quick-start)
+- [Topicable Derive](#topicable-derive)
+- [Generated Implementation](#generated-implementation)
+
+## Quick Start
+
+For normal DDS applications, add the main binding:
+
+```toml
+[dependencies]
+eclipse-cyclonedds = "0.0.2"
+serde = { version = "1", features = ["derive"] }
+```
+
+Then derive `Topicable` on a named-field struct:
+
+```rust
+use cyclonedds::{Domain, Participant, Topic, Topicable};
+
+#[derive(Topicable, serde::Serialize, serde::Deserialize, Clone, Default, Debug)]
+#[dds(type_name = "Sensor")]
+struct Sensor {
+    #[dds(key)]
+    id: u32,
+    temperature: f32,
+}
+
+fn main() -> cyclonedds::Result<()> {
+    let domain = Domain::default();
+    let participant = Participant::new(&domain)?;
+    let topic = Topic::<Sensor>::new(&participant, "Sensor")?;
+
+    Ok(())
+}
+```
+
+See the [main crate documentation][eclipse-cyclonedds-docs] for actually
+interacting with DDS.
+
+## Topicable Derive
+
+`#[derive(Topicable)]` implements `cyclonedds::Topicable` for a named-field
+struct. The payload type must also satisfy the trait bounds required by
+`Topicable`, including `serde::Serialize`, `serde::Deserialize`, `Clone`, and
+`Debug`.
+
+Supported attributes:
+
+- `#[dds(key)]` on fields that make up the DDS instance key.
+- `#[dds(type_name = "...")]` on the struct to override the DDS type name used
+  for topic matching.
+
+For now the derive macro rejects enums, unions, and tuple structs.
+
+## Generated Implementation
+
+For keyed topics, fields marked with `#[dds(key)]` are collected into a hidden
+generated key type. That type implements the serialization and keyhash support
+needed for keys in DDS. You can refer to the key type created by this macro
+through the main crate's `cyclonedds::Key<T>` type alias:
+
+```rust
+use cyclonedds::{Key, Topicable};
+
+#[derive(Topicable, serde::Serialize, serde::Deserialize, Clone, Default, Debug)]
+struct Position {
+    #[dds(key)]
+    x: i32,
+    #[dds(key)]
+    y: i32,
+    label: String,
+}
+
+let position = Position {
+    x: 1,
+    y: 2,
+    label: "origin".to_string(),
+};
+
+// Access the generated Key type via `Key<Position>`.
+let key: Key<Position> = position.as_key();
+assert_eq!(key, Key::<Position> { x: 1, y: 2 });
+```
+
+For unkeyed topics, the generated implementation uses `()` as the key type.
+`from_key` returns `Default::default()`, so unkeyed derived types must implement
+`Default`.
+
+## Minimum Supported Rust Version
+
+For now, the MSRV is the latest stable Rust version at the time of release.
+
+## References
+
+- [Rust binding for Eclipse Cyclone DDS][eclipse-cyclonedds]
+- [Cyclone DDS][cyclonedds-github]
+- [Cyclone DDS Documentation][cyclonedds-docs]
+- [OMG DDS Specification][dds-spec]
+- [OMG DDSI-RTPS specification][ddsi-rtps-spec]
+- [OMG DDS Wiki][omg-dds-wiki]
+- [Contributing](../CONTRIBUTING.md)
+- [Security Policy](../SECURITY.md)
+
+[check-workflow]: https://github.com/eclipse-cyclonedds/cyclonedds-rust/actions/workflows/check.yml
+[check-workflow-status-shield]: https://img.shields.io/github/actions/workflow/status/eclipse-cyclonedds/cyclonedds-rust/check.yml
+[community]: https://discord.gg/4QQvWZrFKF
+[community-shield]: https://img.shields.io/discord/960814229844291604.svg?logo=discord
+[crates.io]: https://crates.io/crates/eclipse-cyclonedds-macros
+[crates.io-shield]: https://img.shields.io/crates/v/eclipse-cyclonedds-macros.svg
+[cyclonedds-docs]: https://cyclonedds.io/docs
+[cyclonedds-github]: https://github.com/eclipse-cyclonedds/cyclonedds
+[cyclonedds-homepage]: https://cyclonedds.io
+[cyclonedds-homepage-shield]: https://img.shields.io/badge/web-cyclonedds.io-blue
+[dds-spec]: https://www.omg.org/spec/DDS/1.4/About-DDS/
+[ddsi-rtps-spec]: https://www.omg.org/spec/DDSI-RTPS/
+[docs.rs]: https://docs.rs/eclipse-cyclonedds-macros
+[docs.rs-shield]: https://docs.rs/eclipse-cyclonedds-macros/badge.svg
+[eclipse-cyclonedds]: https://crates.io/crates/eclipse-cyclonedds
+[eclipse-cyclonedds-docs]: https://docs.rs/eclipse-cyclonedds
+[edl-license]: https://choosealicense.com/licenses/edl-1.0/
+[edl-license-shield]: https://img.shields.io/badge/license-EDL%201.0-blue
+[epl-license]: https://choosealicense.com/licenses/epl-2.0/
+[epl-license-shield]: https://img.shields.io/badge/license-EPL%202.0-blue
+[omg-dds-wiki]: https://www.omgwiki.org/ddsf/doku.php?id=ddsf:public:guidebook:01_front:4_toc

--- a/cyclonedds-macros/src/lib.rs
+++ b/cyclonedds-macros/src/lib.rs
@@ -187,9 +187,9 @@ pub fn derive_topicable(input: TokenStream) -> TokenStream {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use syn::parse_quote;
+
+    use super::*;
 
     #[test]
     fn test_derive_parses_key_fields() {

--- a/cyclonedds-macros/src/lib.rs
+++ b/cyclonedds-macros/src/lib.rs
@@ -81,28 +81,38 @@ impl ToTokens for TopicableAttributes {
                 }
             });
 
-            tokens.extend(
-                quote! {
-                    #[allow(non_snake_case)]
+            let key_name = format!("Key<{ident}>");
+            let key_field_names = keys.iter().map(|f| &f.ident);
+            tokens.extend(quote! {
+                #[allow(non_snake_case)]
+                #[doc(hidden)]
+                mod #key_mod {
                     #[doc(hidden)]
-                    mod #key_mod {
-                        #[doc(hidden)]
-                        #[derive(Default, serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Hash)]
-                        pub struct Key {
-                            #(#key_field_defs),*
-                        }
+                    #[derive(Default, serde::Serialize, serde::Deserialize, Clone, PartialEq, Hash)]
+                    pub struct Key {
+                        #(#key_field_defs),*
+                    }
 
-                        impl ::cyclonedds::cdr_bounds::CdrBounds for Key {
-                            fn max_serialized_cdr_size() -> ::cyclonedds::cdr_bounds::CdrSize {
-                                #(#key_size_sum)+*
-                            }
-                            fn alignment() -> usize {
-                                0 #(.max(#key_alignment_max))*
-                            }
+                    impl std::fmt::Debug for Key {
+                        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                            let mut debug = f.debug_struct(#key_name);
+                            #(
+                                debug.field(stringify!(#key_field_names), &self.#key_field_names);
+                            )*
+                            debug.finish()
+                        }
+                    }
+
+                    impl ::cyclonedds::cdr_bounds::CdrBounds for Key {
+                        fn max_serialized_cdr_size() -> ::cyclonedds::cdr_bounds::CdrSize {
+                            #(#key_size_sum)+*
+                        }
+                        fn alignment() -> usize {
+                            0 #(.max(#key_alignment_max))*
                         }
                     }
                 }
-            );
+            });
             (
                 quote!(#key_mod::Key),
                 quote! {

--- a/cyclonedds-sys/README.md
+++ b/cyclonedds-sys/README.md
@@ -1,12 +1,12 @@
 # Raw FFI Bindings for Eclipse Cyclone DDS
 
-[![License][epl-license-shield]][epl-license]
-[![License][edl-license-shield]][edl-license]
 [![Latest Version][crates.io-shield]][crates.io]
-[![Documentation][docs.rs-shield]][docs.rs]
 [![Build Status][check-workflow-status-shield]][check-workflow]
-[![Website][cyclonedds-homepage-shield]][cyclonedds-homepage]
 [![Community][community-shield]][community]
+[![Website][cyclonedds-homepage-shield]][cyclonedds-homepage]
+
+[![Documentation][docs.rs-shield]][docs.rs]
+[![Dependency Status][deps.rs-shield]][deps.rs]
 
 Raw Rust FFI bindings for [Eclipse Cyclone DDS][cyclonedds-github].
 
@@ -106,23 +106,21 @@ For now, the MSRV is the latest stable Rust version at the time of release.
 - [Security Policy](../SECURITY.md)
 
 [check-workflow]: https://github.com/eclipse-cyclonedds/cyclonedds-rust/actions/workflows/check.yml
-[check-workflow-status-shield]: https://img.shields.io/github/actions/workflow/status/eclipse-cyclonedds/cyclonedds-rust/check.yml
+[check-workflow-status-shield]: https://shieldcn.dev/github/ci/eclipse-cyclonedds/cyclonedds-rust?no-track&mode=light&size=xs
 [community]: https://discord.gg/4QQvWZrFKF
-[community-shield]: https://img.shields.io/discord/960814229844291604.svg?logo=discord
+[community-shield]: https://shieldcn.dev/discord/960814229844291604.svg?no-track&variant=branded&size=xs
 [crates.io]: https://crates.io/crates/eclipse-cyclonedds-sys
-[crates.io-shield]: https://img.shields.io/crates/v/eclipse-cyclonedds-sys.svg
+[crates.io-shield]: https://shieldcn.dev/group/crates/eclipse-cyclonedds-sys+crates/license/eclipse-cyclonedds-sys.svg?no-track&mode=light&size=xs
 [cyclonedds-docs]: https://cyclonedds.io/docs
 [cyclonedds-github]: https://github.com/eclipse-cyclonedds/cyclonedds
 [cyclonedds-homepage]: https://cyclonedds.io
-[cyclonedds-homepage-shield]: https://img.shields.io/badge/web-cyclonedds.io-blue
+[cyclonedds-homepage-shield]: https://shieldcn.dev/badge/web-cyclonedds.io-blue.svg?no-track&mode=light&logo=lu%3ATornado&size=xs
 [dds-spec]: https://www.omg.org/spec/DDS/1.4/About-DDS/
 [ddsi-rtps-spec]: https://www.omg.org/spec/DDSI-RTPS/
+[deps.rs]: https://deps.rs/repo/github/eclipse-cyclonedds/cyclonedds-rust
+[deps.rs-shield]: https://deps.rs/repo/github/eclipse-cyclonedds/cyclonedds-rust/status.svg
 [docs.rs]: https://docs.rs/eclipse-cyclonedds-sys
 [docs.rs-shield]: https://docs.rs/eclipse-cyclonedds-sys/badge.svg
 [eclipse-cyclonedds]: https://crates.io/crates/eclipse-cyclonedds
 [eclipse-cyclonedds-docs]: https://docs.rs/eclipse-cyclonedds
-[edl-license]: https://choosealicense.com/licenses/edl-1.0/
-[edl-license-shield]: https://img.shields.io/badge/license-EDL%201.0-blue
-[epl-license]: https://choosealicense.com/licenses/epl-2.0/
-[epl-license-shield]: https://img.shields.io/badge/license-EPL%202.0-blue
 [omg-dds-wiki]: https://www.omgwiki.org/ddsf/doku.php?id=ddsf:public:guidebook:01_front:4_toc

--- a/cyclonedds-sys/README.md
+++ b/cyclonedds-sys/README.md
@@ -28,14 +28,14 @@ For normal DDS applications, add the main binding:
 
 ```toml
 [dependencies]
-eclipse-cyclonedds = "0.0.2"
+eclipse-cyclonedds = "0.0.3"
 ```
 
 Use this crate directly for raw FFI integration:
 
 ```toml
 [dependencies]
-eclipse-cyclonedds-sys = "0.0.2"
+eclipse-cyclonedds-sys = "0.0.3"
 ```
 
 The crate exposes the generated bindings under the Rust library name
@@ -75,7 +75,7 @@ To build Cyclone DDS from the sources bundled with this crate, enable the
 
 ```toml
 [dependencies]
-eclipse-cyclonedds-sys = { version = "0.0.2", features = ["vendored"] }
+eclipse-cyclonedds-sys = { version = "0.0.3", features = ["vendored"] }
 ```
 
 It requires `cmake` and `libclang` to be available.

--- a/cyclonedds-sys/README.md
+++ b/cyclonedds-sys/README.md
@@ -1,1 +1,128 @@
-../README.md
+# Raw FFI Bindings for Eclipse Cyclone DDS
+
+[![License][epl-license-shield]][epl-license]
+[![License][edl-license-shield]][edl-license]
+[![Latest Version][crates.io-shield]][crates.io]
+[![Documentation][docs.rs-shield]][docs.rs]
+[![Build Status][check-workflow-status-shield]][check-workflow]
+[![Website][cyclonedds-homepage-shield]][cyclonedds-homepage]
+[![Community][community-shield]][community]
+
+Raw Rust FFI bindings for [Eclipse Cyclone DDS][cyclonedds-github].
+
+This crate is the low-level `bindgen` layer used by
+[`eclipse-cyclonedds`][eclipse-cyclonedds]. Most applications should depend on
+`eclipse-cyclonedds`, which provides the safe Rust API, topic support, QoS
+builders, readers, writers, waitsets, and sample handling.
+
+Depend on `eclipse-cyclonedds-sys` directly only when you need access to the C
+API surface itself.
+
+- [Quick Start](#quick-start)
+- [Linking Cyclone DDS](#linking-cyclone-dds)
+- [Generated Bindings](#generated-bindings)
+
+## Quick Start
+
+For normal DDS applications, add the main binding:
+
+```toml
+[dependencies]
+eclipse-cyclonedds = "0.0.2"
+```
+
+Use this crate directly for raw FFI integration:
+
+```toml
+[dependencies]
+eclipse-cyclonedds-sys = "0.0.2"
+```
+
+The crate exposes the generated bindings under the Rust library name
+`cyclonedds_sys`:
+
+```rust
+use cyclonedds_sys as sys;
+
+fn main() {
+    let domain = sys::DOMAIN_DEFAULT;
+    println!("default DDS domain: {domain}");
+}
+```
+
+Direct use of these bindings follows the safety contract of the Cyclone DDS C
+API. Prefer the safe `eclipse-cyclonedds` crate unless you specifically need raw
+FFI.
+
+## Linking Cyclone DDS
+
+By default, this crate expects the Cyclone DDS C library and headers to be
+available on the system. The build script links against `ddsc` and generates
+bindings from `wrapper.h`.
+
+If Cyclone DDS is installed outside the system search paths, set
+`CYCLONEDDS_HOME` to the installation prefix:
+
+```sh
+CYCLONEDDS_HOME=/opt/cyclonedds cargo build
+```
+
+The build script will then look for headers under `$CYCLONEDDS_HOME/include` and
+libraries under `$CYCLONEDDS_HOME/lib` or `$CYCLONEDDS_HOME/lib64`.
+
+To build Cyclone DDS from the sources bundled with this crate, enable the
+`vendored` feature:
+
+```toml
+[dependencies]
+eclipse-cyclonedds-sys = { version = "0.0.2", features = ["vendored"] }
+```
+
+It requires `cmake` and `libclang` to be available.
+
+## Generated Bindings
+
+Bindings are generated at build time with `bindgen` and included from Cargo's
+`OUT_DIR`. It contains raw pointers, C layout types, platform-specific
+definitions, and functions that are unsafe to call without satisfying the C API
+preconditions.
+
+See the [main crate documentation][eclipse-cyclonedds-docs] for the safe
+ergonomic Rust API.
+
+## Minimum Supported Rust Version
+
+For now, the MSRV is the latest stable Rust version at the time of release.
+
+## References
+
+- [Rust binding for Eclipse Cyclone DDS][eclipse-cyclonedds]
+- [Cyclone DDS][cyclonedds-github]
+- [Cyclone DDS Documentation][cyclonedds-docs]
+- [OMG DDS Specification][dds-spec]
+- [OMG DDSI-RTPS specification][ddsi-rtps-spec]
+- [OMG DDS Wiki][omg-dds-wiki]
+- [Contributing](../CONTRIBUTING.md)
+- [Security Policy](../SECURITY.md)
+
+[check-workflow]: https://github.com/eclipse-cyclonedds/cyclonedds-rust/actions/workflows/check.yml
+[check-workflow-status-shield]: https://img.shields.io/github/actions/workflow/status/eclipse-cyclonedds/cyclonedds-rust/check.yml
+[community]: https://discord.gg/4QQvWZrFKF
+[community-shield]: https://img.shields.io/discord/960814229844291604.svg?logo=discord
+[crates.io]: https://crates.io/crates/eclipse-cyclonedds-sys
+[crates.io-shield]: https://img.shields.io/crates/v/eclipse-cyclonedds-sys.svg
+[cyclonedds-docs]: https://cyclonedds.io/docs
+[cyclonedds-github]: https://github.com/eclipse-cyclonedds/cyclonedds
+[cyclonedds-homepage]: https://cyclonedds.io
+[cyclonedds-homepage-shield]: https://img.shields.io/badge/web-cyclonedds.io-blue
+[dds-spec]: https://www.omg.org/spec/DDS/1.4/About-DDS/
+[ddsi-rtps-spec]: https://www.omg.org/spec/DDSI-RTPS/
+[docs.rs]: https://docs.rs/eclipse-cyclonedds-sys
+[docs.rs-shield]: https://docs.rs/eclipse-cyclonedds-sys/badge.svg
+[eclipse-cyclonedds]: https://crates.io/crates/eclipse-cyclonedds
+[eclipse-cyclonedds-docs]: https://docs.rs/eclipse-cyclonedds
+[edl-license]: https://choosealicense.com/licenses/edl-1.0/
+[edl-license-shield]: https://img.shields.io/badge/license-EDL%201.0-blue
+[epl-license]: https://choosealicense.com/licenses/epl-2.0/
+[epl-license-shield]: https://img.shields.io/badge/license-EPL%202.0-blue
+[omg-dds-wiki]: https://www.omgwiki.org/ddsf/doku.php?id=ddsf:public:guidebook:01_front:4_toc

--- a/cyclonedds/src/entity.rs
+++ b/cyclonedds/src/entity.rs
@@ -25,7 +25,12 @@ pub struct EntityId {
     pub(crate) inner: cyclonedds_sys::dds_entity_t,
 }
 
-// TODO should the Entity trait be sealed?
+mod private {
+    /// Private trait for sealing downstream implementation of the
+    /// [`Entity`](super::Entity) trait.
+    pub trait Sealed {}
+}
+
 /// Common interface implemented by all members of the DDS entity hierarchy.
 ///
 /// - [`Participant`](crate::Participant): the root entity representing
@@ -51,7 +56,7 @@ pub struct EntityId {
 ///       - [`QueryCondition<T, F>`](crate::QueryCondition): filters
 ///         [`Reader`](crate::Reader) samples by [`sample state`](crate::State)
 ///         and a predicate.
-pub trait Entity {
+pub trait Entity: private::Sealed {
     /// Returns the [`EntityId`] of this entity.
     ///
     /// # Examples
@@ -351,6 +356,8 @@ pub trait Entity {
 
 macro_rules! impl_entity {
     ($ty:ty) => {
+        impl private::Sealed for $ty {}
+
         impl Entity for $ty {
             fn id(&self) -> EntityId {
                 EntityId { inner: self.inner }
@@ -358,6 +365,8 @@ macro_rules! impl_entity {
         }
     };
     ($ty:ty where $($bounds:tt)*) => {
+        impl<$($bounds)*> private::Sealed for $ty {}
+
         impl<$($bounds)*> Entity for $ty {
             fn id(&self) -> EntityId {
                 EntityId { inner: self.inner }

--- a/cyclonedds/src/entity.rs
+++ b/cyclonedds/src/entity.rs
@@ -33,29 +33,22 @@ mod private {
 
 /// Common interface implemented by all members of the DDS entity hierarchy.
 ///
-/// - [`Participant`](crate::Participant): the root entity representing
-///   membership in a domain.
-///   - [`WaitSet`](crate::WaitSet): blocks until one or more attached
-///     conditions are triggered.
-///   - [`GuardCondition`](crate::GuardCondition): a manually triggered
-///     condition for use with a [`WaitSet`](crate::WaitSet).
-///   - [`Topic<T>`](crate::Topic): names and types a data channel for a
-///     specific payload type `T`.
-///   - [`Publisher`](crate::Publisher): groups [`Writers`](crate::Writer) and
-///     controls their shared [`QoS`](crate::QoS).
-///     - [`Writer<T>`](crate::Writer): publishes samples of type `T` to a
-///       [`Topic`](crate::Topic).
-///   - [`Subscriber`](crate::Subscriber): groups [`Readers`](crate::Reader) and
-///     controls their shared [`QoS`](crate::QoS).
-///     - [`Reader<T>`](crate::Reader): receives samples of type `T` from a
-///       [`Topic`](crate::Topic).
-///       - [`ReadCondition<T>`](crate::ReadCondition): filters
-///         [`Reader`](crate::Reader) samples by
+/// - [`Participant`](crate::Participant): the root entity representing membership in a domain.
+///   - [`WaitSet`](crate::WaitSet): blocks until one or more attached conditions are triggered.
+///   - [`GuardCondition`](crate::GuardCondition): a manually triggered condition for use with a
+///     [`WaitSet`](crate::WaitSet).
+///   - [`Topic<T>`](crate::Topic): names and types a data channel for a specific payload type `T`.
+///   - [`Publisher`](crate::Publisher): groups [`Writers`](crate::Writer) and controls their shared
+///     [`QoS`](crate::QoS).
+///     - [`Writer<T>`](crate::Writer): publishes samples of type `T` to a [`Topic`](crate::Topic).
+///   - [`Subscriber`](crate::Subscriber): groups [`Readers`](crate::Reader) and controls their
+///     shared [`QoS`](crate::QoS).
+///     - [`Reader<T>`](crate::Reader): receives samples of type `T` from a [`Topic`](crate::Topic).
+///       - [`ReadCondition<T>`](crate::ReadCondition): filters [`Reader`](crate::Reader) samples by
 ///         [`sample`](crate::state::sample), [`view`](crate::state::view), and
 ///         [`instance`](crate::state::instance) state.
-///       - [`QueryCondition<T, F>`](crate::QueryCondition): filters
-///         [`Reader`](crate::Reader) samples by [`sample state`](crate::State)
-///         and a predicate.
+///       - [`QueryCondition<T, F>`](crate::QueryCondition): filters [`Reader`](crate::Reader)
+///         samples by [`sample state`](crate::State) and a predicate.
 pub trait Entity: private::Sealed {
     /// Returns the [`EntityId`] of this entity.
     ///
@@ -130,12 +123,11 @@ pub trait Entity: private::Sealed {
     ///
     /// # Errors
     ///
-    /// - Returns an [`Error`](crate::Error) if the status bits of the
-    ///   corresponding entity could not be retrieved (e.g. the entity no longer
-    ///   exists).
+    /// - Returns an [`Error`](crate::Error) if the status bits of the corresponding entity could
+    ///   not be retrieved (e.g. the entity no longer exists).
     ///
-    /// - Returns [`BadParameter`](crate::Error::BadParameter) if the retrieved
-    ///   bits do not correspond to a valid [`Status`].
+    /// - Returns [`BadParameter`](crate::Error::BadParameter) if the retrieved bits do not
+    ///   correspond to a valid [`Status`].
     ///
     /// # Examples
     ///
@@ -181,13 +173,12 @@ pub trait Entity: private::Sealed {
     ///
     /// # Errors
     ///
-    /// - Returns an [`Error`](crate::Error) if the status bits of the
-    ///   corresponding entity could not be retrieved (e.g. the entity no longer
-    ///   exists or the status mask contains entries that do not apply to the
-    ///   entity type).
+    /// - Returns an [`Error`](crate::Error) if the status bits of the corresponding entity could
+    ///   not be retrieved (e.g. the entity no longer exists or the status mask contains entries
+    ///   that do not apply to the entity type).
     ///
-    /// - Returns [`BadParameter`](crate::Error::BadParameter) if the retrieved
-    ///   bits do not correspond to a valid [`Status`].
+    /// - Returns [`BadParameter`](crate::Error::BadParameter) if the retrieved bits do not
+    ///   correspond to a valid [`Status`].
     ///
     /// # Examples
     ///
@@ -229,12 +220,11 @@ pub trait Entity: private::Sealed {
     ///
     /// # Errors
     ///
-    /// - Returns an [`Error`](crate::Error) if the status bits of the
-    ///   corresponding entity could not be retrieved (e.g. the entity no longer
-    ///   exists).
+    /// - Returns an [`Error`](crate::Error) if the status bits of the corresponding entity could
+    ///   not be retrieved (e.g. the entity no longer exists).
     ///
-    /// - Returns [`BadParameter`](crate::Error::BadParameter) if the retrieved
-    ///   bits do not correspond to a valid [`Status`].
+    /// - Returns [`BadParameter`](crate::Error::BadParameter) if the retrieved bits do not
+    ///   correspond to a valid [`Status`].
     ///
     /// # Examples
     ///
@@ -275,12 +265,11 @@ pub trait Entity: private::Sealed {
     ///
     /// # Errors
     ///
-    /// - Returns an [`Error`](crate::Error) if the status mask of the
-    ///   corresponding entity could not be retrieved (e.g. the entity no longer
-    ///   exists).
+    /// - Returns an [`Error`](crate::Error) if the status mask of the corresponding entity could
+    ///   not be retrieved (e.g. the entity no longer exists).
     ///
-    /// - Returns [`BadParameter`](crate::Error::BadParameter) if the retrieved
-    ///   bits do not correspond to a valid [`Status`].
+    /// - Returns [`BadParameter`](crate::Error::BadParameter) if the retrieved bits do not
+    ///   correspond to a valid [`Status`].
     ///
     /// # Examples
     /// ```
@@ -321,9 +310,8 @@ pub trait Entity: private::Sealed {
     ///
     /// # Errors
     ///
-    /// - Returns an [`Error`](crate::Error) if the status mask of the
-    ///   corresponding entity could not be set (e.g. the entity no longer
-    ///   exists).
+    /// - Returns an [`Error`](crate::Error) if the status mask of the corresponding entity could
+    ///   not be set (e.g. the entity no longer exists).
     ///
     /// # Examples
     /// ```

--- a/cyclonedds/src/internal/ffi.rs
+++ b/cyclonedds/src/internal/ffi.rs
@@ -731,12 +731,8 @@ where
     let buffer = unsafe { &mut *(arg.cast::<Vec<crate::sample::SampleOrKey<T>>>()) };
 
     let info = unsafe { &*info };
-    let mut _sertype = std::mem::ManuallyDrop::new(unsafe {
-        Box::from_raw(sertype as *mut crate::internal::sertype::Sertype<T>)
-    });
-    let mut serdata = std::mem::ManuallyDrop::new(unsafe {
-        Box::from_raw(serdata.cast::<crate::internal::serdata::Serdata<T>>())
-    });
+    let _sertype = unsafe { &mut *(sertype as *mut crate::internal::sertype::Sertype<T>) };
+    let serdata = unsafe { &mut *(serdata.cast::<crate::internal::serdata::Serdata<T>>()) };
 
     let valid_data = info.valid_data;
     let info: crate::sample::Info = info.into();

--- a/cyclonedds/src/internal/ffi/serdata_ops.rs
+++ b/cyclonedds/src/internal/ffi/serdata_ops.rs
@@ -187,15 +187,14 @@ where
 ///
 /// ## Safety
 /// - `serdata` must be a non-null pointer to a fully-initialized [`Serdata`].
-/// - `containers` must point to a valid contiguous array of `ddsrt_iovec_t`
-///   structures of length `containers_len`. Each `iov_base` must be a valid
-///   pointer to `iov_len` bytes of readable memory.
-/// - `size` must be less than or equal to the total number of bytes described
-///   by the `ddsrt_iovec_t` array, or else out-of-bounds memory will be
-///   accessed when copying data.
-/// - `T` must match the expected deserialized type, and the deserialization
-///   must not violate any invariants assumed by the type (e.g., panic during
-///   construction or interior mutability issues).
+/// - `containers` must point to a valid contiguous array of `ddsrt_iovec_t` structures of length
+///   `containers_len`. Each `iov_base` must be a valid pointer to `iov_len` bytes of readable
+///   memory.
+/// - `size` must be less than or equal to the total number of bytes described by the
+///   `ddsrt_iovec_t` array, or else out-of-bounds memory will be accessed when copying data.
+/// - `T` must match the expected deserialized type, and the deserialization must not violate any
+///   invariants assumed by the type (e.g., panic during construction or interior mutability
+///   issues).
 pub unsafe extern "C" fn from_ser_iov<T>(
     sertype: *const cyclonedds_sys::ddsi_sertype,
     kind: cyclonedds_sys::ddsi_serdata_kind,
@@ -363,8 +362,7 @@ pub unsafe extern "C" fn to_ser<T>(
 ///
 /// ## Safety
 /// - `serdata`  must be a non-null pointer to a fully-initialized [`Serdata`].
-/// - `container` must be a non-null pointer to an
-///   [`cyclonedds_sys::ddsrt_iovec_t`].
+/// - `container` must be a non-null pointer to an [`cyclonedds_sys::ddsrt_iovec_t`].
 pub unsafe extern "C" fn to_ser_ref<T>(
     serdata: *const cyclonedds_sys::ddsi_serdata,
     offset: usize,
@@ -415,10 +413,8 @@ pub unsafe extern "C" fn to_ser_unref<T>(
 /// Returns `true` if a sample was present and copied, `false` otherwise.
 ///
 /// ## Safety
-/// - `sertype` must be a valid, non-null pointer to a heap-allocated
-///   [`Sertype`].
-/// - `sample` must be a valid, non-null pointer that can hold a value of size
-///   `T`.
+/// - `sertype` must be a valid, non-null pointer to a heap-allocated [`Sertype`].
+/// - `sample` must be a valid, non-null pointer that can hold a value of size `T`.
 pub unsafe extern "C" fn to_sample<T>(
     serdata: *const cyclonedds_sys::ddsi_serdata,
     sample: *mut std::ffi::c_void,
@@ -457,8 +453,7 @@ where
 /// Create an untyped sertype based on provided typed [`Serdata`].
 ///
 /// ## Safety
-/// - `sertype` must be a valid, non-null pointer to a heap-allocated
-///   [`Sertype`].
+/// - `sertype` must be a valid, non-null pointer to a heap-allocated [`Sertype`].
 pub unsafe extern "C" fn to_untyped<T>(
     serdata: *const cyclonedds_sys::ddsi_serdata,
 ) -> *mut cyclonedds_sys::ddsi_serdata

--- a/cyclonedds/src/internal/ffi/serdata_ops.rs
+++ b/cyclonedds/src/internal/ffi/serdata_ops.rs
@@ -34,8 +34,8 @@ pub unsafe extern "C" fn eqkey<T>(
 where
     T: crate::Topicable,
 {
-    let mut lhs = std::mem::ManuallyDrop::new(unsafe { Box::from_raw(lhs as *mut Serdata<T>) });
-    let mut rhs = std::mem::ManuallyDrop::new(unsafe { Box::from_raw(rhs as *mut Serdata<T>) });
+    let lhs = unsafe { &mut *(lhs as *mut Serdata<T>) };
+    let rhs = unsafe { &mut *(rhs as *mut Serdata<T>) };
 
     lhs.key() == rhs.key()
 }
@@ -50,8 +50,7 @@ pub unsafe extern "C" fn get_size<T>(serdata: *const cyclonedds_sys::ddsi_serdat
 where
     T: crate::Topicable,
 {
-    let mut serdata =
-        std::mem::ManuallyDrop::new(unsafe { Box::from_raw(serdata as *mut Serdata<T>) });
+    let serdata = unsafe { &mut *(serdata as *mut Serdata<T>) };
 
     u32::try_from(
         serdata
@@ -168,7 +167,7 @@ pub unsafe extern "C" fn from_ser<T>(
 where
     T: crate::Topicable,
 {
-    let sertype = std::mem::ManuallyDrop::new(unsafe { Box::from_raw(sertype as *mut Sertype<T>) });
+    let sertype = unsafe { &mut *(sertype as *mut Sertype<T>) };
 
     if fragment_chain.is_null() {
         return std::ptr::null_mut();
@@ -177,7 +176,7 @@ where
     crate::internal::serdata::Kind::try_from(kind).map_or(std::ptr::null_mut(), |kind| {
         let fragment_chain = unsafe { &*fragment_chain };
         copy_from_fragment(fragment_chain, size).map_or(std::ptr::null_mut(), |buffer| {
-            from_ser_buffer(&sertype, kind, &buffer)
+            from_ser_buffer(sertype, kind, &buffer)
         })
     })
 }
@@ -205,7 +204,7 @@ pub unsafe extern "C" fn from_ser_iov<T>(
 where
     T: crate::Topicable,
 {
-    let sertype = std::mem::ManuallyDrop::new(unsafe { Box::from_raw(sertype as *mut Sertype<T>) });
+    let sertype = unsafe { &mut *(sertype as *mut Sertype<T>) };
 
     crate::internal::serdata::Kind::try_from(kind).map_or(std::ptr::null_mut(), |kind| {
         let mut buffer: Vec<u8> = Vec::with_capacity(size);
@@ -242,7 +241,7 @@ where
             buffer.extend_from_slice(container);
             offset += len;
         }
-        from_ser_buffer(&sertype, kind, &buffer)
+        from_ser_buffer(sertype, kind, &buffer)
     })
 }
 
@@ -280,10 +279,10 @@ where
     T: crate::Topicable,
 {
     let force_md5 = T::FORCE_MD5_KEYHASH;
-    let sertype = std::mem::ManuallyDrop::new(unsafe { Box::from_raw(sertype as *mut Sertype<T>) });
+    let sertype = unsafe { &mut *(sertype as *mut Sertype<T>) };
     let keyhash = unsafe { &*keyhash };
 
-    from_keyhash_with_mode::<T>(&sertype, keyhash, force_md5)
+    from_keyhash_with_mode::<T>(sertype, keyhash, force_md5)
 }
 
 /// Constructs a [`Serdata`] from a sample pointer, given a serialization kind.
@@ -301,38 +300,34 @@ where
     let sample = unsafe { &*(sample.cast::<InternalSample<'_, T>>()) };
     match (crate::internal::serdata::Kind::try_from(kind), sample) {
         (Ok(crate::internal::serdata::Kind::Data), InternalSample::SampleRef(sample)) => {
-            let sertype =
-                std::mem::ManuallyDrop::new(unsafe { Box::from_raw(sertype as *mut Sertype<T>) });
+            let sertype = unsafe { &mut *(sertype as *mut Sertype<T>) };
 
             let sample = SampleOrKey::new_sample((*sample).clone());
-            let serdata = Box::new(Serdata::new(sertype.as_ref(), sample));
+            let serdata = Box::new(Serdata::new(sertype, sample));
 
             Box::into_raw(serdata).cast()
         }
         (Ok(crate::internal::serdata::Kind::Data), InternalSample::Sample(sample)) => {
-            let sertype =
-                std::mem::ManuallyDrop::new(unsafe { Box::from_raw(sertype as *mut Sertype<T>) });
+            let sertype = unsafe { &mut *(sertype as *mut Sertype<T>) };
 
             let sample = SampleOrKey::new_sample(sample.clone());
-            let serdata = Box::new(Serdata::new(sertype.as_ref(), sample));
+            let serdata = Box::new(Serdata::new(sertype, sample));
 
             Box::into_raw(serdata).cast()
         }
         (Ok(crate::internal::serdata::Kind::Key), InternalSample::KeyRef(key)) => {
-            let sertype =
-                std::mem::ManuallyDrop::new(unsafe { Box::from_raw(sertype as *mut Sertype<T>) });
+            let sertype = unsafe { &mut *(sertype as *mut Sertype<T>) };
 
             let key = SampleOrKey::new_key((*key).clone());
-            let serdata = Box::new(Serdata::new(sertype.as_ref(), key));
+            let serdata = Box::new(Serdata::new(sertype, key));
 
             Box::into_raw(serdata).cast()
         }
         (Ok(crate::internal::serdata::Kind::Key), InternalSample::Key(key)) => {
-            let sertype =
-                std::mem::ManuallyDrop::new(unsafe { Box::from_raw(sertype as *mut Sertype<T>) });
+            let sertype = unsafe { &mut *(sertype as *mut Sertype<T>) };
 
             let key = SampleOrKey::new_key(key.clone());
-            let serdata = Box::new(Serdata::new(sertype.as_ref(), key));
+            let serdata = Box::new(Serdata::new(sertype, key));
 
             Box::into_raw(serdata).cast()
         }
@@ -372,8 +367,7 @@ pub unsafe extern "C" fn to_ser_ref<T>(
 where
     T: crate::Topicable,
 {
-    let mut serdata =
-        std::mem::ManuallyDrop::new(unsafe { Box::from_raw(serdata as *mut Serdata<T>) });
+    let serdata = unsafe { &mut *(serdata as *mut Serdata<T>) };
     let container = unsafe { &mut *container };
 
     serdata
@@ -401,8 +395,7 @@ pub unsafe extern "C" fn to_ser_unref<T>(
 ) where
     T: crate::Topicable,
 {
-    let mut serdata =
-        std::mem::ManuallyDrop::new(unsafe { Box::from_raw(serdata.cast::<Serdata<T>>()) });
+    let serdata = unsafe { &mut *(serdata.cast::<Serdata<T>>()) };
 
     crate::internal::ffi::ddsi_serdata_unref(&mut serdata.inner);
 }
@@ -427,8 +420,7 @@ where
     if sample.is_null() {
         false
     } else {
-        let mut serdata =
-            std::mem::ManuallyDrop::new(unsafe { Box::from_raw(serdata as *mut Serdata<T>) });
+        let serdata = unsafe { &mut *(serdata as *mut Serdata<T>) };
 
         let sample = sample.cast::<InternalSample<'_, T>>();
         match serdata.kind() {
@@ -460,14 +452,12 @@ pub unsafe extern "C" fn to_untyped<T>(
 where
     T: crate::Topicable,
 {
-    let serdata = std::mem::ManuallyDrop::new(unsafe { Box::from_raw(serdata as *mut Serdata<T>) });
+    let serdata = unsafe { &mut *(serdata as *mut Serdata<T>) };
 
-    let sertype = std::mem::ManuallyDrop::new(unsafe {
-        Box::from_raw(serdata.inner.type_ as *mut Sertype<T>)
-    });
+    let sertype = unsafe { &mut *(serdata.inner.type_ as *mut Sertype<T>) };
 
     let mut untyped_serdata = Box::new(Serdata::new(
-        sertype.as_ref(),
+        sertype,
         SampleOrKey::new_key(serdata.sample.as_ref().key().clone()),
     ));
     untyped_serdata.inner.type_ = std::ptr::null_mut();
@@ -490,8 +480,7 @@ where
     if sample.is_null() {
         false
     } else {
-        let mut serdata =
-            std::mem::ManuallyDrop::new(unsafe { Box::from_raw(serdata as *mut Serdata<T>) });
+        let serdata = unsafe { &mut *(serdata as *mut Serdata<T>) };
 
         let sample = sample.cast::<InternalSample<'_, T>>();
         match serdata.kind() {
@@ -542,7 +531,7 @@ pub unsafe extern "C" fn print<T>(
 where
     T: crate::Topicable,
 {
-    let serdata = std::mem::ManuallyDrop::new(unsafe { Box::from_raw(serdata as *mut Serdata<T>) });
+    let serdata = unsafe { &mut *(serdata as *mut Serdata<T>) };
 
     let buffer = unsafe { std::slice::from_raw_parts_mut(buffer.cast(), length) };
     let mut cursor = std::io::Cursor::new(&mut *buffer);
@@ -577,8 +566,7 @@ pub unsafe extern "C" fn get_keyhash<T>(
 ) where
     T: crate::Topicable,
 {
-    let mut serdata =
-        std::mem::ManuallyDrop::new(unsafe { Box::from_raw(serdata as *mut Serdata<T>) });
+    let serdata = unsafe { &mut *(serdata as *mut Serdata<T>) };
     let keyhash = unsafe { &mut *keyhash };
 
     KeyHash::from_key::<T>(serdata.key(), force_md5)

--- a/cyclonedds/src/internal/ffi/serdata_ops.rs
+++ b/cyclonedds/src/internal/ffi/serdata_ops.rs
@@ -55,7 +55,7 @@ where
     u32::try_from(
         serdata
             .serialized()
-            .expect("unable to serialize data") // TODO pass this back out somehow?
+            .expect("unable to serialize data")
             .len(),
     )
     .expect("serialized data out of bounds")
@@ -498,8 +498,10 @@ where
 /// Deallocate a [`Serdata`].
 ///
 /// ## Safety
-/// `serdata` must point to a valid previously allocated [`Serdata`].
-/// TODO.
+/// - `serdata` must be a non-null pointer to a previously allocated [`Serdata<T>`].
+/// - Cyclone DDS must call this only after the [`ddsi_serdata`][cyclonedds_sys::ddsi_serdata]
+///   reference count has reached zero. After this call, no other references or serialized-data
+///   loans may be used, and the pointer must not be passed to this function again.
 pub unsafe extern "C" fn free<T>(serdata: *mut cyclonedds_sys::ddsi_serdata)
 where
     T: crate::Topicable,
@@ -520,8 +522,11 @@ where
 /// the null terminator.
 ///
 /// ## Safety
-/// `serdata` must point to a valid previously allocated [`Serdata`].
-/// TODO.
+/// - `_sertype` must be either the [`Sertype<T>`] for `serdata` or the compatible type supplied by
+///   Cyclone DDS when printing untyped serdata.
+/// - `serdata` must be a non-null pointer to a fully-initialized [`Serdata<T>`].
+/// - `buffer` must be non-null, valid for writes of `length` bytes, and `length` must be greater
+///   than zero so the required trailing NULL terminator can be written.
 pub unsafe extern "C" fn print<T>(
     _sertype: *const cyclonedds_sys::ddsi_sertype,
     serdata: *const cyclonedds_sys::ddsi_serdata,

--- a/cyclonedds/src/internal/ffi/sertype_ops.rs
+++ b/cyclonedds/src/internal/ffi/sertype_ops.rs
@@ -201,10 +201,8 @@ pub unsafe extern "C" fn free_samples<T>(
 /// Compares two [`Sertype`] instances for equality.
 ///
 /// # Safety
-/// - The `lhs` and `rhs` must point to `Sertype`s previously constructed by the
-///   Rust API.
-/// - The `type_name` field of the pointers must be a valid null-terminated
-///   string.
+/// - The `lhs` and `rhs` must point to `Sertype`s previously constructed by the Rust API.
+/// - The `type_name` field of the pointers must be a valid null-terminated string.
 pub unsafe extern "C" fn equal<T>(
     lhs: *const cyclonedds_sys::ddsi_sertype,
     rhs: *const cyclonedds_sys::ddsi_sertype,

--- a/cyclonedds/src/internal/ffi/sertype_ops.rs
+++ b/cyclonedds/src/internal/ffi/sertype_ops.rs
@@ -84,9 +84,10 @@ where
     drop(sertype);
 }
 
+/// Zero out samples.
 ///
-/// TODO: validate what the purpose of this is in the actual functioning of
-/// Cyclone? The C++ API also maps this to a no-op.
+/// This is used for generating samples from just a key value and in cleaning up
+/// after a loan is returned.
 pub unsafe extern "C" fn zero_samples<T>(
     _sertype: *const cyclonedds_sys::ddsi_sertype,
     samples: *mut std::ffi::c_void,
@@ -372,8 +373,6 @@ where
         false
     } else {
         let sample = unsafe { &*(sample.cast::<InternalSample<'_, T>>()) };
-        // TODO verify if the to_writer interface errors if it reaches the bounds of the
-        // buffer.
         match (
             crate::internal::serdata::Kind::try_from(serdata_kind),
             sample,

--- a/cyclonedds/src/internal/ffi/sertype_ops.rs
+++ b/cyclonedds/src/internal/ffi/sertype_ops.rs
@@ -210,8 +210,8 @@ pub unsafe extern "C" fn equal<T>(
 where
     T: crate::Topicable,
 {
-    let lhs = std::mem::ManuallyDrop::new(unsafe { Box::from_raw(lhs as *mut Sertype<T>) });
-    let rhs = std::mem::ManuallyDrop::new(unsafe { Box::from_raw(rhs as *mut Sertype<T>) });
+    let lhs = unsafe { &mut *(lhs as *mut Sertype<T>) };
+    let rhs = unsafe { &mut *(rhs as *mut Sertype<T>) };
 
     // Also base this on the type support identifier?
     unsafe { CStr::from_ptr(lhs.inner.type_name) == CStr::from_ptr(rhs.inner.type_name) }
@@ -226,7 +226,7 @@ pub unsafe extern "C" fn hash<T>(sertype: *const cyclonedds_sys::ddsi_sertype) -
 where
     T: crate::Topicable,
 {
-    let sertype = std::mem::ManuallyDrop::new(unsafe { Box::from_raw(sertype as *mut Sertype<T>) });
+    let sertype = unsafe { &mut *(sertype as *mut Sertype<T>) };
 
     let name = unsafe { CStr::from_ptr(sertype.inner.type_name) };
     let type_size = std::mem::size_of::<T>();

--- a/cyclonedds/src/internal/key_hash.rs
+++ b/cyclonedds/src/internal/key_hash.rs
@@ -25,7 +25,9 @@ impl KeyHash {
                     // The CDR serialized form fits and can be used as the key hash but
                     // it must be padded to 16 bytes and those padding bytes must be zeroed.
                     serialized.resize(16.max(serialized.len()), 0);
-                    // TODO could this possibly fail?
+                    // This should only fail if `max_serialized_cdr_size()` is incorrect, e.g. it
+                    // reports a maximum size of 16 bytes or less while the serialized key is
+                    // actually larger than 16 bytes.
                     serialized.try_into().ok()?
                 };
 

--- a/cyclonedds/src/lib.rs
+++ b/cyclonedds/src/lib.rs
@@ -42,17 +42,15 @@
 //! a collection of
 //! [`QoS policies`](qos::policy) that configure characteristics such as:
 //!
-//! - [`durability`](qos::policy::Durability) (whether late-joining readers
-//!   receive historical samples)
+//! - [`durability`](qos::policy::Durability) (whether late-joining readers receive historical
+//!   samples)
 //!
-//! - [`reliability`](qos::policy::Reliability) (best-effort vs reliable
-//!   delivery)
+//! - [`reliability`](qos::policy::Reliability) (best-effort vs reliable delivery)
 //!
-//! - [`history depth`](qos::policy::History) (the number of samples to store in
-//!   history)
+//! - [`history depth`](qos::policy::History) (the number of samples to store in history)
 //!
-//! - [`deadline`](qos::policy::Deadline) (whether a signal should be generated
-//!   when a sample is not received within a specified period)
+//! - [`deadline`](qos::policy::Deadline) (whether a signal should be generated when a sample is not
+//!   received within a specified period)
 //!
 //! Policies are set independently on the writer and reader side, and
 //! compatibility is checked at discovery time. A writer's offered [`QoS`] must
@@ -104,8 +102,7 @@
 //! # struct MyData {
 //! #     x: i32,
 //! # }
-//! use cyclonedds::qos;
-//! use cyclonedds::{QoS, Reader, Subscriber, Topic, Writer};
+//! use cyclonedds::{QoS, Reader, Subscriber, Topic, Writer, qos};
 //!
 //! let topic = Topic::<MyData>::new(&participant, "MyTopic")?;
 //!

--- a/cyclonedds/src/lib.rs
+++ b/cyclonedds/src/lib.rs
@@ -68,7 +68,11 @@
 //! [`ReadConditions`](ReadCondition), and [`QueryConditions`](QueryCondition):
 //! Mechanisms to trigger the condition associated with a waitset.
 //!
-//! See the [DDS Specification](https://www.omg.org/spec/DDS/1.4/About-DDS/) and the [OMG DDS Wiki](https://www.omgwiki.org/ddsf/doku.php?id=ddsf:public:guidebook:01_front:4_toc) for these other elements and see the rest of the Rust Documentation for what is supported by this API.//!
+//! See the [DDS Specification](https://www.omg.org/spec/DDS/1.4/About-DDS/) and the
+//! [OMG DDS Wiki](https://www.omgwiki.org/ddsf/doku.php?id=ddsf:public:guidebook:01_front:4_toc)
+//! for these other elements and see the rest of the Rust Documentation for what
+//! is supported by this API.
+//!
 //!
 //! # Getting started
 //!

--- a/cyclonedds/src/listener.rs
+++ b/cyclonedds/src/listener.rs
@@ -37,8 +37,7 @@
 //! constructing separate listeners for each level.
 //!
 //! ```
-//! use cyclonedds::Listener;
-//! use cyclonedds::{Domain, Participant, Subscriber};
+//! use cyclonedds::{Domain, Listener, Participant, Subscriber};
 //!
 //! let domain = Domain::default();
 //!
@@ -86,16 +85,15 @@
 //! and [`Writer<T>`](crate::Writer) that all have different types for `<T>`. As
 //! a result, one of two obvious solutions presents itself:
 //!
-//! - Allow these higher-level types to only have callbacks of effectively
-//!   [`std::any::Any`] and require the callback to attempt to convert. This
-//!   maps the most correctly onto how the API is designed in the specification
-//!   but would greatly complicate the internal dispatching of these listeners.
+//! - Allow these higher-level types to only have callbacks of effectively [`std::any::Any`] and
+//!   require the callback to attempt to convert. This maps the most correctly onto how the API is
+//!   designed in the specification but would greatly complicate the internal dispatching of these
+//!   listeners.
 //!
-//! - Maintain a typed registry of all the different types of callbacks that are
-//!   attached on the higher-level untyped subscribers and then add code to
-//!   check if the event that fired corresponds to a type whose callback was
-//!   registered. This would work but introduces semantics that do not match the
-//!   other DDS implementations.
+//! - Maintain a typed registry of all the different types of callbacks that are attached on the
+//!   higher-level untyped subscribers and then add code to check if the event that fired
+//!   corresponds to a type whose callback was registered. This would work but introduces semantics
+//!   that do not match the other DDS implementations.
 //!
 //! </div>
 //!
@@ -103,8 +101,7 @@
 //!
 //! ```
 //! use cyclonedds::entity::Entity;
-//! use cyclonedds::{Reader, Topic, Writer};
-//! use cyclonedds::{ReaderListener, TopicListener, WriterListener};
+//! use cyclonedds::{Reader, ReaderListener, Topic, TopicListener, Writer, WriterListener};
 //! # #[derive(
 //! #     cyclonedds::Topicable, serde::Serialize, serde::Deserialize, Clone, Debug, Default,
 //! # )]

--- a/cyclonedds/src/participant.rs
+++ b/cyclonedds/src/participant.rs
@@ -178,7 +178,8 @@ impl<'d> Participant<'d> {
     /// # Examples
     ///
     /// ```
-    /// use cyclonedds::{Domain, Listener, Participant, listener::SubscriberListener};
+    /// use cyclonedds::listener::SubscriberListener;
+    /// use cyclonedds::{Domain, Listener, Participant};
     ///
     /// let domain = Domain::default();
     /// let mut participant = Participant::new(&domain)?;

--- a/cyclonedds/src/publisher.rs
+++ b/cyclonedds/src/publisher.rs
@@ -167,10 +167,8 @@ impl<'d, 'p> Publisher<'d, 'p> {
     /// # Examples
     ///
     /// ```
-    /// use cyclonedds::{
-    ///     Publisher, QoS,
-    ///     qos::policy::{Durability, Presentation},
-    /// };
+    /// use cyclonedds::qos::policy::{Durability, Presentation};
+    /// use cyclonedds::{Publisher, QoS};
     /// # use cyclonedds::{Domain, Participant};
     /// # let domain = Domain::default();
     /// # let participant = Participant::new(&domain)?;

--- a/cyclonedds/src/qos.rs
+++ b/cyclonedds/src/qos.rs
@@ -863,6 +863,16 @@ mod tests {
     }
 
     #[test]
+    #[should_panic = "unable to safely create std::ffi::CString from partition name"]
+    fn test_qos_set_partition_with_invalid_name() {
+        let partition = policy::Partition {
+            partitions: vec!["A".to_string(), "\0".to_string()],
+        };
+        let qos = QoS::new().with_partition(partition.clone());
+        assert_eq!(qos.partition, Some(partition));
+    }
+
+    #[test]
     fn test_qos_set_reliability() {
         let reliability = policy::Reliability::BestEffort;
         let qos = QoS::new().with_reliability(reliability);

--- a/cyclonedds/src/qos/policy.rs
+++ b/cyclonedds/src/qos/policy.rs
@@ -4,11 +4,14 @@
 //! in the DCPS specification. Policies are set on a [`QoS`](crate::QoS)
 //! instance via its
 //! `with_*` methods and applied to entities through their builders.
+//! Some policies only apply to specific entity types; when applied
+//! they cascade to the appropriate entities automatically.
 //!
-//! Not all policies apply to all entity types. Refer to the DDS specification
-//! or Cyclone DDS documentation for the applicability of each policy.
-
-// TODO add the details on what QoS policies apply to what types here too.
+//! See to the [DDS specification] and the [Cyclone DDS documentation] for
+//! the applicability and semantics of each policy.
+//!
+//! [DDS specification]: https://www.omg.org/spec/DDS/1.4/About-DDS/
+//! [Cyclone DDS documentation]: https://cyclonedds.io/docs
 
 use crate::Duration;
 use crate::internal::traits::AsFfi;

--- a/cyclonedds/src/qos/policy.rs
+++ b/cyclonedds/src/qos/policy.rs
@@ -383,9 +383,12 @@ impl AsFfi for Partition {
         self.partitions
             .iter()
             .map(|partition| {
-                std::ffi::CString::new(partition.as_str()).unwrap_or_else(|err| panic!(
-                    "unable to safely create std::ffi::CString from partition name: {partition:?}: {err}"
-                ))
+                std::ffi::CString::new(partition.as_str()).unwrap_or_else(|err| {
+                    panic!(
+                        "unable to safely create std::ffi::CString from partition name: \
+                         {partition:?}: {err}"
+                    )
+                })
             })
             .collect()
     }

--- a/cyclonedds/src/qos/policy.rs
+++ b/cyclonedds/src/qos/policy.rs
@@ -383,9 +383,9 @@ impl AsFfi for Partition {
         self.partitions
             .iter()
             .map(|partition| {
-                std::ffi::CString::new(partition.as_str()).expect(
-                    "TODO should this be moved to the construction of the partition policy?",
-                )
+                std::ffi::CString::new(partition.as_str()).unwrap_or_else(|err| panic!(
+                    "unable to safely create std::ffi::CString from partition name: {partition:?}: {err}"
+                ))
             })
             .collect()
     }
@@ -711,9 +711,11 @@ impl AsFfi for EntityName {
 
     #[inline]
     fn as_ffi(&self) -> Self::Target<'_> {
-        // TODO should this be moved to the construction of the name policy or deferred
-        // to the set_qos + construction of the objects with the QoS?O
-        std::ffi::CString::new(self.name.as_str())
-            .expect("unable to safely create std::ffi::CString from entity name")
+        std::ffi::CString::new(self.name.as_str()).unwrap_or_else(|err| {
+            panic!(
+                "unable to safely create std::ffi::CString from entity name: {:?}: {err}",
+                self.name
+            )
+        })
     }
 }

--- a/cyclonedds/src/query_condition.rs
+++ b/cyclonedds/src/query_condition.rs
@@ -24,10 +24,10 @@ use crate::{Reader, Result};
 ///
 /// In practice, this means the callback must be either:
 ///
-///   - a [function item](https://doc.rust-lang.org/reference/types/function-item.html),
-///     which is always zero-sized, or
-///   - a [closure](https://doc.rust-lang.org/reference/types/closure.html) that
-///     does not capture any variables from its environment
+///   - a [function item](https://doc.rust-lang.org/reference/types/function-item.html), which is
+///     always zero-sized, or
+///   - a [closure](https://doc.rust-lang.org/reference/types/closure.html) that does not capture
+///     any variables from its environment
 ///
 /// The following example will **fail to compile** because the closure captures
 /// `x`, making it non-zero-sized:

--- a/cyclonedds/src/read_condition.rs
+++ b/cyclonedds/src/read_condition.rs
@@ -12,8 +12,7 @@ use crate::{Reader, Result, State};
 /// # Examples
 ///
 /// ```no_run
-/// use cyclonedds::state;
-/// use cyclonedds::{Duration, ReadCondition, WaitSet};
+/// use cyclonedds::{Duration, ReadCondition, WaitSet, state};
 /// # use cyclonedds::{Domain, Participant, Topic, Reader};
 /// # let domain = Domain::default();
 /// # let participant = Participant::new(&domain)?;

--- a/cyclonedds/src/reader.rs
+++ b/cyclonedds/src/reader.rs
@@ -112,9 +112,8 @@ where
     /// # Examples
     ///
     /// ```
-    /// use cyclonedds::ReaderListener;
-    /// use cyclonedds::Subscriber;
     /// use cyclonedds::builder::ReaderBuilder;
+    /// use cyclonedds::{ReaderListener, Subscriber};
     /// # use cyclonedds::{Domain, Participant, Topic};
     /// # let domain = Domain::default();
     /// # let participant = Participant::new(&domain)?;
@@ -258,7 +257,8 @@ where
     /// # Examples
     ///
     /// ```
-    /// use cyclonedds::{QoS, Reader, qos::policy::History};
+    /// use cyclonedds::qos::policy::History;
+    /// use cyclonedds::{QoS, Reader};
     ///
     /// # use cyclonedds::{Domain, Participant, Topic};
     /// # let domain = Domain::default();

--- a/cyclonedds/src/status.rs
+++ b/cyclonedds/src/status.rs
@@ -304,9 +304,6 @@ pub struct SampleLost {
 /// limits`](crate::qos::policy::ResourceLimits).
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SampleRejectedReason {
-    // TODO How can sample not rejected be a valid status for the sample
-    // rejected status? should this be modeled as an Option in
-    // samplerejected?
     /// The sample was not rejected.
     NotRejected,
     /// Rejected because the maximum number of instances has been reached.

--- a/cyclonedds/src/subscriber.rs
+++ b/cyclonedds/src/subscriber.rs
@@ -170,10 +170,8 @@ impl<'d, 'p> Subscriber<'d, 'p> {
     /// # Examples
     ///
     /// ```
-    /// use cyclonedds::{
-    ///     QoS, Subscriber,
-    ///     qos::policy::{Durability, Presentation},
-    /// };
+    /// use cyclonedds::qos::policy::{Durability, Presentation};
+    /// use cyclonedds::{QoS, Subscriber};
     /// # use cyclonedds::{Domain, Participant};
     /// # let domain = Domain::default();
     /// # let participant = Participant::new(&domain)?;

--- a/cyclonedds/src/writer.rs
+++ b/cyclonedds/src/writer.rs
@@ -112,9 +112,8 @@ where
     /// # Examples
     ///
     /// ```
-    /// use cyclonedds::Publisher;
-    /// use cyclonedds::WriterListener;
     /// use cyclonedds::builder::WriterBuilder;
+    /// use cyclonedds::{Publisher, WriterListener};
     /// # use cyclonedds::{Domain, Participant, Topic};
     /// # let domain = Domain::default();
     /// # let participant = Participant::new(&domain)?;
@@ -261,7 +260,8 @@ where
     /// # Examples
     ///
     /// ```
-    /// use cyclonedds::{Duration, QoS, Writer, qos::policy::Reliability};
+    /// use cyclonedds::qos::policy::Reliability;
+    /// use cyclonedds::{Duration, QoS, Writer};
     /// # use cyclonedds::{Domain, Participant, Topic};
     /// # let domain = Domain::default();
     /// # let participant = Participant::new(&domain)?;

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,8 @@
   '';
 
   inputs = {
+    # Specify that we need submodules for the vendored sources.
+    self.submodules = true;
     # Nix
     nixpkgs-stable.url = "github:nixos/nixpkgs?ref=nixos-26.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs?ref=nixos-unstable";


### PR DESCRIPTION
This mainly address all of my outstanding `TODO`s that aren't related to adding new features. It also tightens up some error messages, seals the `Entity` trait to prevent downstream implementers, reduces most of my uses of `std::mem::ManuallyDrop<Box<T>>`, and adds that the `nix flake` expects to have the Cyclone submodule available out of the box.

I'm also including a generated changelog based on the info from [`noxpardalis/gitch`](https://github.com/noxpardalis/gitch) to hopefully serve as an overview. (Let me know if including this is too noisy/not helpful @eboasson)

---

### Fixed

- Swap `std::mem::ManuallyDrop<Box<T>>` to `&mut *ptr` throughout the FFI layer where ownership is not being transferred
- Seal the `Entity` trait to prevent downstream implementations
- Improve panic messages for `Partition` and `EntityName` when a null byte is present in the string

### Documentation

- Add common footguns section to `README.md` covering QoS mismatch, offer/request asymmetry, durability, history depth, domain ID isolation, partition mismatch, liveliness, and `read`/`take`/`peek` semantics
- Add specialized READMEs for `cyclonedds-sys` and `cyclonedds-macros`
- Improve `qos/policy.rs` module doc to clarify that QoS policies cascade to the appropriate entities automatically
- Address TODOs in `serdata_ops`, `sertype_ops`, `key_hash`, and `status`
- Run formatter under nightly configuration

### Build

- Specify `self.submodules = true` in `flake.nix` using the native Nix 2.27 mechanism, removing the separate submodule flake check CI steps

### Chore

- Add renamed `cyclonedds-macros` crate to `.check-commits.yaml` scope
- Remove stale comment on `SampleRejectedReason`
- Bump crate versions to `0.0.3`