### PR TITLE
Fix `vendored` builds under release and get coverage to 100%

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,7 @@
 [profile.default]
 slow-timeout = { period = "5s", terminate-after = 2 }
+
+[[profile.default.overrides]]
+# Increase timeout for trybuild compilation
+filter = 'package(eclipse-cyclonedds-macros)'
+slow-timeout = { period = "30s", terminate-after = 2 }

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,9 +52,13 @@ jobs:
       - name: run clippy
         run: nix develop -c cargo clippy -- --deny warnings
       - name: run tests
-        run: nix develop -c cargo nextest run
+        run: |
+          nix develop -c cargo nextest run
+          nix develop -c cargo nextest run --release
       - name: run doc tests
-        run: nix develop -c cargo test --doc
+        run: |
+          nix develop -c cargo test --doc
+          nix develop -c cargo test --doc --release
 
       - name: check coverage
         run: nix develop -c cargo llvm-cov nextest --fail-under-functions 95
@@ -73,7 +77,12 @@ jobs:
       - name: run tests with vendored cyclone
         run: |
           nix develop .#vendoring -c cargo nextest run --features vendored
+          nix develop .#vendoring -c cargo nextest run --features vendored --release
+
+      - name: run doc tests with vendored cyclone
+        run: |
           nix develop .#vendoring -c cargo test --doc --features vendored
+          nix develop .#vendoring -c cargo test --doc --features vendored --release
          
       - name: run additional flake checks
         run: nix flake check
@@ -135,7 +144,12 @@ jobs:
       - name: run tests with vendored cyclone
         run: |
           nix develop .#vendoring -c cargo nextest run --features vendored
+          nix develop .#vendoring -c cargo nextest run --features vendored --release
+
+      - name: run doc tests with vendored cyclone
+        run: |
           nix develop .#vendoring -c cargo test --doc --features vendored
+          nix develop .#vendoring -c cargo test --doc --features vendored --release
          
       - name: run additional flake checks
         run: nix flake check
@@ -165,7 +179,9 @@ jobs:
         run: cargo clippy --features vendored -- --deny warnings
 
       - name: run tests
-        run: cargo test --features vendored
+        run: |
+          cargo test --features vendored
+          cargo test --features vendored --release
 
         # TODO add semver checks
         # TODO add all the checkers

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: true
 
       - name: set up nix
-        uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
         with:
           nix_conf: |
             keep-env-derivations = true
@@ -39,6 +39,13 @@ jobs:
           purge-created: 0
           purge-last-accessed: P1DT12H
           purge-primary-key: never
+          paths: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/registry/src/
+            ~/.cargo/git/db/
+            target
 
       - name: set up nix devshells
         run: |
@@ -60,9 +67,6 @@ jobs:
           nix develop -c cargo test --doc
           nix develop -c cargo test --doc --release
 
-      - name: check coverage
-        run: nix develop -c cargo llvm-cov nextest --fail-under-functions 95
-          --fail-under-lines 95 --fail-under-regions 95
       - name: check coverage (with branch coverage)
         run: nix develop .#nightly -c cargo llvm-cov nextest --branch --fail-under-functions 95
           --fail-under-lines 95 --fail-under-regions 95
@@ -94,12 +98,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: true
 
       - name: set up nix
-        uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
         with:
           nix_conf: |
             keep-env-derivations = true
@@ -115,6 +119,13 @@ jobs:
           purge-created: 0
           purge-last-accessed: P1DT12H
           purge-primary-key: never
+          paths: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/registry/src/
+            ~/.cargo/git/db/
+            target
 
       - name: set up nix devshells
         run: |
@@ -132,12 +143,6 @@ jobs:
       - name: run doc tests
         run: nix develop -c cargo test --doc
 
-      - name: check coverage
-        run: nix develop -c cargo llvm-cov nextest --fail-under-functions 95
-          --fail-under-lines 95 --fail-under-regions 95
-      - name: check coverage (with branch coverage)
-        run: nix develop .#nightly -c cargo llvm-cov nextest --branch --fail-under-functions 95
-          --fail-under-lines 95 --fail-under-regions 95
       - name: run cargo deny
         run: nix develop -c cargo deny check
 
@@ -150,24 +155,23 @@ jobs:
         run: |
           nix develop .#vendoring -c cargo test --doc --features vendored
           nix develop .#vendoring -c cargo test --doc --features vendored --release
-         
-      - name: run additional flake checks
-        run: nix flake check
 
   check-windows:
     strategy:
       matrix:
-        # os: [windows-latest]
         os: [windows-latest, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: true
 
       - name: install rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: cache rust
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: cargo check
         run: cargo check --features vendored

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,7 +31,7 @@ jobs:
       - name: cache nix store
         uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
         with:
-          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock', '**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
           gc-max-store-size-linux: 9G
           purge: true
@@ -111,7 +111,7 @@ jobs:
       - name: cache nix store
         uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
         with:
-          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock', '**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}
           gc-max-store-size-linux: 9G
           purge: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,40 @@
+name: generate coverage reports
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: true
+
+      - name: set up nix
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+
+      - name: set up nix devshell
+        run: nix develop .#nightly
+
+      - name: check coverage (with branch coverage)
+        run: nix develop .#nightly -c cargo llvm-cov nextest --branch --codecov --output-path codecov.json
+
+      - name: upload coverage to codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: codecov.json
+          fail_ci_if_error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+ "trybuild",
 ]
 
 [[package]]
@@ -624,6 +625,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +675,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +691,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -695,6 +720,60 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "trybuild"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]
@@ -824,6 +903,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +925,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "eclipse-cyclonedds"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "eclipse-cyclonedds-macros"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "eclipse-cyclonedds-sys"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "bindgen",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ homepage = "https://cyclonedds.io/"
 repository = "https://github.com/eclipse-cyclonedds/cyclonedds-rust"
 license = "EPL-2.0 OR BSD-3-Clause"
 authors = ["Troy Karan Harrison <troy.harrison@zettascale.tech>"]
-description = "Rust binding for Eclipse Cyclone DDS"
 
 [workspace.dependencies]
 eclipse-cyclonedds-sys = { version = "0.0.3", path = "cyclonedds-sys" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cyclonedds", "cyclonedds-sys", "cyclonedds-macros"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.3"
+version = "0.0.4"
 edition = "2024"
 homepage = "https://cyclonedds.io/"
 repository = "https://github.com/eclipse-cyclonedds/cyclonedds-rust"
@@ -11,8 +11,8 @@ license = "EPL-2.0 OR BSD-3-Clause"
 authors = ["Troy Karan Harrison <troy.harrison@zettascale.tech>"]
 
 [workspace.dependencies]
-eclipse-cyclonedds-sys = { version = "0.0.3", path = "cyclonedds-sys" }
-eclipse-cyclonedds-macros = { version = "0.0.3", path = "cyclonedds-macros" }
+eclipse-cyclonedds-sys = { version = "0.0.4", path = "cyclonedds-sys" }
+eclipse-cyclonedds-macros = { version = "0.0.4", path = "cyclonedds-macros" }
 
 [workspace.metadata.crane]
 name = "eclipse-cyclonedds"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Community][community-shield]][community]
 [![Website][cyclonedds-homepage-shield]][cyclonedds-homepage]
 
+[![Code Coverage][codecov-shield]][codecov]
 [![Documentation][docs.rs-shield]][docs.rs]
 [![Dependency Status][deps.rs-shield]][deps.rs]
 
@@ -287,6 +288,8 @@ For now, the MSRV is the latest stable Rust version at the time of release.
 
 [check-workflow]: https://github.com/eclipse-cyclonedds/cyclonedds-rust/actions/workflows/check.yml
 [check-workflow-status-shield]: https://shieldcn.dev/github/ci/eclipse-cyclonedds/cyclonedds-rust?no-track&mode=light&size=xs
+[codecov]: https://codecov.io/github/eclipse-cyclonedds/cyclonedds-rust
+[codecov-shield]: https://codecov.io/gh/eclipse-cyclonedds/cyclonedds-rust/graph/badge.svg
 [community]: https://discord.gg/4QQvWZrFKF
 [community-shield]: https://shieldcn.dev/discord/960814229844291604.svg?no-track&variant=branded&size=xs
 [crates.io]: https://crates.io/crates/eclipse-cyclonedds

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ via the `vendored` feature. Then add the package to your `Cargo.toml` via:
 #
 # NOTE: you can also point to Cyclone DDS using the `CYCLONEDDS_HOME` variable if
 # performing a full installation is undesirable.
-eclipse-cyclonedds = "0.0.3"
+eclipse-cyclonedds = "0.0.4"
 
 # Using the `vendored` feature will result in us compiling and linking in a version
 # of Cyclone DDS for you.
-eclipse-cyclonedds = { version = "0.0.3", features = ["vendored"] }
+eclipse-cyclonedds = { version = "0.0.4", features = ["vendored"] }
 ```
 
 Then see [the example](#example) and [the docs][docs.rs] to get started.

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ will be invisible to each other if their domain IDs differ.
 
 Partitions introduce a second matching layer on top of topic name and `QoS`. A
 writer and reader on the same topic will not exchange samples unless they share
-at least one partition string note that the empty string `""` a valid and
+at least one partition string. Note that the empty string `""` is a valid and
 distinct partition.
 
 ### Liveliness
@@ -265,7 +265,7 @@ matched/unmatched transitions on the reader side.
 in the reader cache, so subsequent reads with overlapping state masks may return
 the same samples again. `take` removes them, making those samples unavailable to
 any later call. Use `take` for queue-like consumption and `read` when you need
-to inspect the current state without draining it.
+to inspect the current state without draining the sample.
 
 Cyclone DDS also includes a `peek` call which reads without updating any sample
 or view state, so repeated peeks always see the same samples regardless of state

--- a/cyclonedds-macros/Cargo.toml
+++ b/cyclonedds-macros/Cargo.toml
@@ -22,3 +22,6 @@ syn = { version = "2", default-features = false, features = [
   "derive",
   "printing",
 ] }
+
+[dev-dependencies]
+trybuild = "1.0.116"

--- a/cyclonedds-macros/Cargo.toml
+++ b/cyclonedds-macros/Cargo.toml
@@ -6,7 +6,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 authors.workspace = true
-description.workspace = true
+description = "Procedural Macros for Eclipse Cyclone DDS"
 
 [lib]
 name = "cyclonedds_macros"

--- a/cyclonedds-macros/README.md
+++ b/cyclonedds-macros/README.md
@@ -5,6 +5,7 @@
 [![Community][community-shield]][community]
 [![Website][cyclonedds-homepage-shield]][cyclonedds-homepage]
 
+[![Code Coverage][codecov-shield]][codecov]
 [![Documentation][docs.rs-shield]][docs.rs]
 [![Dependency Status][deps.rs-shield]][deps.rs]
 
@@ -132,6 +133,8 @@ For now, the MSRV is the latest stable Rust version at the time of release.
 
 [check-workflow]: https://github.com/eclipse-cyclonedds/cyclonedds-rust/actions/workflows/check.yml
 [check-workflow-status-shield]: https://shieldcn.dev/github/ci/eclipse-cyclonedds/cyclonedds-rust?no-track&mode=light&size=xs
+[codecov]: https://codecov.io/github/eclipse-cyclonedds/cyclonedds-rust
+[codecov-shield]: https://codecov.io/gh/eclipse-cyclonedds/cyclonedds-rust/graph/badge.svg
 [community]: https://discord.gg/4QQvWZrFKF
 [community-shield]: https://shieldcn.dev/discord/960814229844291604.svg?no-track&variant=branded&size=xs
 [crates.io]: https://crates.io/crates/eclipse-cyclonedds-macros

--- a/cyclonedds-macros/README.md
+++ b/cyclonedds-macros/README.md
@@ -38,7 +38,7 @@ For normal DDS applications, add the main binding:
 
 ```toml
 [dependencies]
-eclipse-cyclonedds = "0.0.3"
+eclipse-cyclonedds = "0.0.4"
 serde = { version = "1", features = ["derive"] }
 ```
 

--- a/cyclonedds-macros/src/lib.rs
+++ b/cyclonedds-macros/src/lib.rs
@@ -187,12 +187,9 @@ impl ToTokens for TopicableAttributes {
 #[proc_macro_derive(Topicable, attributes(dds))]
 pub fn derive_topicable(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
-    let topicable = match TopicableAttributes::from_derive_input(&input) {
-        Ok(v) => v,
-        Err(e) => return e.write_errors().into(),
-    };
-
-    topicable.to_token_stream().into()
+    TopicableAttributes::from_derive_input(&input)
+        .map(|topicable| topicable.to_token_stream().into())
+        .unwrap_or_else(|e| e.write_errors().into())
 }
 
 #[cfg(test)]

--- a/cyclonedds-macros/tests/compilation-failure/topicable_enum.rs
+++ b/cyclonedds-macros/tests/compilation-failure/topicable_enum.rs
@@ -1,0 +1,9 @@
+use cyclonedds_macros::Topicable;
+
+#[derive(Topicable)]
+enum Data {
+    Variant1 { x: i32, y: i32 },
+    Variant2(i32, u32),
+}
+
+fn main() {}

--- a/cyclonedds-macros/tests/compilation-failure/topicable_enum.stderr
+++ b/cyclonedds-macros/tests/compilation-failure/topicable_enum.stderr
@@ -1,0 +1,7 @@
+error: Unsupported shape `enum`. Expected struct with named fields.
+ --> tests/compilation-failure/topicable_enum.rs:3:10
+  |
+3 | #[derive(Topicable)]
+  |          ^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Topicable` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/cyclonedds-macros/tests/compilation-failure/topicable_struct_with_unnamed_fields.rs
+++ b/cyclonedds-macros/tests/compilation-failure/topicable_struct_with_unnamed_fields.rs
@@ -1,0 +1,6 @@
+use cyclonedds_macros::Topicable;
+
+#[derive(Topicable)]
+struct Data(i32, u32);
+
+fn main() {}

--- a/cyclonedds-macros/tests/compilation-failure/topicable_struct_with_unnamed_fields.stderr
+++ b/cyclonedds-macros/tests/compilation-failure/topicable_struct_with_unnamed_fields.stderr
@@ -1,0 +1,7 @@
+error: Unsupported shape `unnamed fields`. Expected named fields.
+ --> tests/compilation-failure/topicable_struct_with_unnamed_fields.rs:3:10
+  |
+3 | #[derive(Topicable)]
+  |          ^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Topicable` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/cyclonedds-macros/tests/topicable.rs
+++ b/cyclonedds-macros/tests/topicable.rs
@@ -1,0 +1,5 @@
+#[test]
+fn test_topicable() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compilation-failure/*.rs");
+}

--- a/cyclonedds-sys/Cargo.toml
+++ b/cyclonedds-sys/Cargo.toml
@@ -1,12 +1,18 @@
 [package]
 name = "eclipse-cyclonedds-sys"
 authors.workspace = true
-description.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 version.workspace = true
+description = "Raw FFI Bindings for Eclipse Cyclone DDS"
+categories = [
+  "automotive",
+  "external-ffi-bindings",
+  "network-programming",
+  "science::robotics",
+]
 
 [lib]
 name = "cyclonedds_sys"

--- a/cyclonedds-sys/README.md
+++ b/cyclonedds-sys/README.md
@@ -5,6 +5,7 @@
 [![Community][community-shield]][community]
 [![Website][cyclonedds-homepage-shield]][cyclonedds-homepage]
 
+[![Code Coverage][codecov-shield]][codecov]
 [![Documentation][docs.rs-shield]][docs.rs]
 [![Dependency Status][deps.rs-shield]][deps.rs]
 
@@ -107,6 +108,8 @@ For now, the MSRV is the latest stable Rust version at the time of release.
 
 [check-workflow]: https://github.com/eclipse-cyclonedds/cyclonedds-rust/actions/workflows/check.yml
 [check-workflow-status-shield]: https://shieldcn.dev/github/ci/eclipse-cyclonedds/cyclonedds-rust?no-track&mode=light&size=xs
+[codecov]: https://codecov.io/github/eclipse-cyclonedds/cyclonedds-rust
+[codecov-shield]: https://codecov.io/gh/eclipse-cyclonedds/cyclonedds-rust/graph/badge.svg
 [community]: https://discord.gg/4QQvWZrFKF
 [community-shield]: https://shieldcn.dev/discord/960814229844291604.svg?no-track&variant=branded&size=xs
 [crates.io]: https://crates.io/crates/eclipse-cyclonedds-sys

--- a/cyclonedds-sys/README.md
+++ b/cyclonedds-sys/README.md
@@ -29,14 +29,14 @@ For normal DDS applications, add the main binding:
 
 ```toml
 [dependencies]
-eclipse-cyclonedds = "0.0.3"
+eclipse-cyclonedds = "0.0.4"
 ```
 
 Use this crate directly for raw FFI integration:
 
 ```toml
 [dependencies]
-eclipse-cyclonedds-sys = "0.0.3"
+eclipse-cyclonedds-sys = "0.0.4"
 ```
 
 The crate exposes the generated bindings under the Rust library name
@@ -76,7 +76,7 @@ To build Cyclone DDS from the sources bundled with this crate, enable the
 
 ```toml
 [dependencies]
-eclipse-cyclonedds-sys = { version = "0.0.3", features = ["vendored"] }
+eclipse-cyclonedds-sys = { version = "0.0.4", features = ["vendored"] }
 ```
 
 It requires `cmake` and `libclang` to be available.

--- a/cyclonedds-sys/build.rs
+++ b/cyclonedds-sys/build.rs
@@ -229,7 +229,9 @@ pub fn generate_bindings(
         .define("BUILD_DDSPERF", "OFF")
         .define("ENABLE_SSL", "NO")
         .define("ENABLE_SECURITY", "NO")
-        .define("CMAKE_INSTALL_LIBDIR", "lib");
+        .define("CMAKE_INSTALL_LIBDIR", "lib")
+        // NOTE: this is to keep the symbols when building with `--release`.
+        .define("ENABLE_LTO", "NO");
 
     if cross_compiling {
         cyclonedds_cmake = cyclonedds_cmake.define("CMAKE_CROSSCOMPILING", "ON");

--- a/cyclonedds/Cargo.toml
+++ b/cyclonedds/Cargo.toml
@@ -1,12 +1,19 @@
 [package]
 name = "eclipse-cyclonedds"
 authors.workspace = true
-description.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 version.workspace = true
+description = "Official Rust binding for Eclipse Cyclone DDS"
+keywords = ["cyclonedds", "dds"]
+categories = [
+  "automotive",
+  "api-bindings",
+  "network-programming",
+  "science::robotics",
+]
 
 [lib]
 name = "cyclonedds"

--- a/cyclonedds/src/internal/ffi/serdata_ops.rs
+++ b/cyclonedds/src/internal/ffi/serdata_ops.rs
@@ -208,26 +208,23 @@ where
 
     crate::internal::serdata::Kind::try_from(kind).map_or(std::ptr::null_mut(), |kind| {
         let mut buffer: Vec<u8> = Vec::with_capacity(size);
-        // NOTE: `ddsrt_msg_iovlen_t` might not be a usize on all platforms and
-        // so the clippy lint warning about unnecessary conversion should be
-        // suppressed.
-        #[allow(clippy::useless_conversion, clippy::manual_let_else)]
-        let containers_len = match usize::try_from(containers_len) {
-            Ok(size) => size,
-            Err(_) => return std::ptr::null_mut(),
+
+        // `ddsrt_msg_iovlen_t` is already a `usize` under Linux
+        #[cfg(not(target_os = "linux"))]
+        let Ok(containers_len) = usize::try_from(containers_len) else {
+            return std::ptr::null_mut();
         };
 
         let containers = unsafe { std::slice::from_raw_parts(containers, containers_len) };
 
         let mut offset = 0;
         for container in containers {
-            // NOTE: `ddsrt_msg_iovlen_t` might not be a usize on all platforms and
-            // so the clippy lint warning about unnecessary conversion should be
-            // suppressed.
-            #[allow(clippy::useless_conversion, clippy::manual_let_else)]
-            let container_iov_len = match usize::try_from(container.iov_len) {
-                Ok(size) => size,
-                Err(_) => return std::ptr::null_mut(),
+            let container_iov_len = container.iov_len;
+
+            // `ddsrt_iov_len_t` is a `usize` for every platform except Windows.
+            #[cfg(target_os = "windows")]
+            let Ok(container_iov_len) = usize::try_from(container_iov_len) else {
+                return std::ptr::null_mut();
             };
 
             let len = if container_iov_len + offset > size {
@@ -376,7 +373,12 @@ where
         .and_then(|serialized| {
             let slice = serialized.get(offset..)?;
             container.iov_base = slice.as_ptr() as *mut _;
-            container.iov_len = cyclonedds_sys::ddsrt_iov_len_t::try_from(slice.len()).ok()?;
+
+            let iov_len = slice.len();
+            // `ddsrt_iov_len_t` is a `usize` for every platform except Windows.
+            #[cfg(target_os = "windows")]
+            let iov_len = cyclonedds_sys::ddsrt_iov_len_t::try_from(iov_len).ok()?;
+            container.iov_len = iov_len;
             Some(())
         })
         .map(|()| unsafe { cyclonedds_sys::ddsi_serdata_ref(&raw const serdata.inner) })

--- a/cyclonedds/src/internal/ffi/sertype_ops.rs
+++ b/cyclonedds/src/internal/ffi/sertype_ops.rs
@@ -26,11 +26,11 @@ impl SertypeVersion {
     pub(crate) const fn as_ffi(self) -> cyclonedds_sys::ddsi_sertype_v0_t {
         match self {
             SertypeVersion::V0 => {
-                #[cfg(not(target_family = "windows"))]
+                #[cfg(not(target_os = "windows"))]
                 {
                     Some(cyclonedds_sys::ddsi_sertype_v0)
                 }
-                #[cfg(target_family = "windows")]
+                #[cfg(target_os = "windows")]
                 {
                     // NOTE: Windows does not have the `dds_sertype_v0` constant exposed and the
                     // underlying value that v0 expects in the C lib for that

--- a/cyclonedds/src/internal/ffi/tests.rs
+++ b/cyclonedds/src/internal/ffi/tests.rs
@@ -1838,3 +1838,31 @@ fn test_sertype_ops_serialize_into() {
     crate::internal::ffi::ddsi_sertype_unref(&mut sertype.inner);
     let _ = Box::into_raw(sertype);
 }
+
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_sertype_version_conversion() {
+    let version = crate::internal::ffi::sertype_ops::SertypeVersion::V0
+        .as_ffi()
+        .unwrap();
+
+    let version = version as usize;
+
+    let expected = cyclonedds_sys::ddsi_sertype_v0 as *const () as usize;
+
+    assert_eq!(version, expected);
+}
+
+#[test]
+#[cfg(target_os = "windows")]
+fn test_sertype_version_conversion() {
+    let version = crate::internal::ffi::sertype_ops::SertypeVersion::V0
+        .as_ffi()
+        .unwrap();
+
+    let version = usize::from(version);
+
+    let expected = 0x01;
+
+    assert_eq!(version, expected);
+}

--- a/cyclonedds/src/internal/ffi/tests.rs
+++ b/cyclonedds/src/internal/ffi/tests.rs
@@ -1866,3 +1866,35 @@ fn test_sertype_version_conversion() {
 
     assert_eq!(version, expected);
 }
+
+#[test]
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+fn test_from_ser_iov_with_msg_iovlen_t_out_of_bounds() {
+    let type_name =
+        std::ffi::CString::new(crate::tests::topic::Data::dds_type_name().as_ref()).unwrap();
+    let topic_has_key = crate::tests::topic::Data::IS_KEYED;
+    let mut sertype = Box::new(
+        crate::internal::sertype::Sertype::<crate::tests::topic::Data>::new(
+            &type_name,
+            topic_has_key,
+        ),
+    );
+
+    let kind = crate::internal::serdata::Kind::Data;
+    let size = 0;
+
+    let containers_len: i32 = -1;
+    let serdata = unsafe {
+        serdata_ops::from_ser_iov::<crate::tests::topic::Data>(
+            &raw mut sertype.inner,
+            kind.into(),
+            containers_len,
+            std::ptr::null_mut(),
+            size,
+        )
+    };
+    assert_eq!(serdata, std::ptr::null_mut());
+
+    crate::internal::ffi::ddsi_sertype_unref(&mut sertype.inner);
+    let _ = Box::into_raw(sertype);
+}

--- a/cyclonedds/src/qos.rs
+++ b/cyclonedds/src/qos.rs
@@ -868,8 +868,7 @@ mod tests {
         let partition = policy::Partition {
             partitions: vec!["A".to_string(), "\0".to_string()],
         };
-        let qos = QoS::new().with_partition(partition.clone());
-        assert_eq!(qos.partition, Some(partition));
+        let _ = QoS::new().with_partition(partition.clone());
     }
 
     #[test]

--- a/cyclonedds/tests/topicable.rs
+++ b/cyclonedds/tests/topicable.rs
@@ -1,0 +1,88 @@
+//! Integration tests validating the `[Topicable]` derive macro.
+
+use cyclonedds as dds;
+use dds::Topicable;
+
+#[test]
+fn test_topicable_on_empty_struct() -> dds::Result<()> {
+    #[derive(Topicable, Debug, Clone, serde::Serialize, serde::Deserialize, Default, PartialEq)]
+    struct Data {}
+
+    let domain = dds::Domain::default();
+    let participant = dds::Participant::new(&domain)?;
+    let topic = dds::Topic::<Data>::new(&participant, "data")?;
+    let reader = dds::Reader::new(&topic)?;
+    let writer = dds::Writer::new(&topic)?;
+
+    let sample = Data {};
+    writer.write(&sample).unwrap();
+
+    let samples = reader.read()?;
+    assert_eq!(*samples[0], sample);
+
+    Ok(())
+}
+
+#[test]
+fn test_topicable_on_unkeyed_data() -> dds::Result<()> {
+    #[derive(Topicable, Debug, Clone, serde::Serialize, serde::Deserialize, Default, PartialEq)]
+    struct Data {
+        x: u32,
+        y: i32,
+    }
+
+    let domain = dds::Domain::default();
+    let participant = dds::Participant::new(&domain)?;
+    let topic = dds::Topic::<Data>::new(&participant, "data")?;
+    let reader = dds::Reader::new(&topic)?;
+    let writer = dds::Writer::new(&topic)?;
+
+    let sample = Data { x: 1, y: 2 };
+    writer.write(&sample)?;
+
+    let samples = reader.read()?;
+    assert_eq!(*samples[0], sample);
+
+    Ok(())
+}
+
+#[test]
+fn test_topicable_with_topic_name() -> dds::Result<()> {
+    #[derive(Topicable, Debug, Clone, serde::Serialize, serde::Deserialize, Default, PartialEq)]
+    #[dds(type_name = "custom::Data")]
+    struct Data {
+        x: u32,
+        y: i32,
+    }
+
+    let domain = dds::Domain::default();
+    let participant = dds::Participant::new(&domain)?;
+    let topic = dds::Topic::<Data>::new(&participant, "data")?;
+    let reader = dds::Reader::new(&topic)?;
+    let writer = dds::Writer::new(&topic)?;
+
+    let sample = Data { x: 1, y: 2 };
+    writer.write(&sample)?;
+
+    let samples = reader.read()?;
+    assert_eq!(*samples[0], sample);
+
+    Ok(())
+}
+
+#[test]
+fn test_topicable_with_invalid_topic_name() -> dds::Result<()> {
+    #[derive(Topicable, Debug, Clone, serde::Serialize, serde::Deserialize, Default, PartialEq)]
+    #[dds(type_name = "custom::Data\0")]
+    struct Data {
+        x: u32,
+        y: i32,
+    }
+
+    let domain = dds::Domain::default();
+    let participant = dds::Participant::new(&domain)?;
+    let error = dds::Topic::<Data>::new(&participant, "data").unwrap_err();
+    assert_eq!(error, dds::Error::BadParameter);
+
+    Ok(())
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -27,7 +27,9 @@ let
       fs.toSource {
         root = src;
         fileset = fs.unions [
+          # `wrapper.h` for bindgen
           (fs.fileFilter (file: file.hasExt "h") src)
+          # crate sources
           (fs.fromSource (crane-lib.cleanCargoSource src))
         ];
       };

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -29,6 +29,8 @@ let
         fileset = fs.unions [
           # `wrapper.h` for bindgen
           (fs.fileFilter (file: file.hasExt "h") src)
+          # `ui` snapshot tests for `trybuild`
+          (fs.fileFilter (file: file.hasExt "stderr") src)
           # crate sources
           (fs.fromSource (crane-lib.cleanCargoSource src))
         ];


### PR DESCRIPTION
The `vendored` build for cyclone was broken due to LTO stripping out the symbols when doing the static build for Cyclone. This PR also does some more housekeeping and gets the current code/branch/region coverage to 100% under Linux and macOS.

This should be the last housekeeping release for a while. Sorry for the rapid cadence with them. The next release will probably take longer and will be focused on adding more features.

**NOTE** the codecov token still needs to be added to the repo so that we can publish the coverage reports.

Here are the reports based on my fork: https://app.codecov.io/github/noxpardalis/cyclonedds-rust

---
## Changelog

### Fixes
- Match C library handling of `ddsrt_msg_iovlen_t` and `ddsrt_iov_len_t` instead of converting unconditionally, fixing rejected valid input on Linux/macOS.
- Use `target_os` instead of `target_family` for the sertype FFI shim.
- Fix `vendored` release builds by disabling LTO (was stripping needed symbols).

### Tests
- Closed coverage gaps for `from_ser_iov` and sertype version conversion. Now at 100% branch/region coverage on macOS and Linux.
- Added `trybuild` compile-fail and integration tests for the `Topicable` derive macro.
- Tests now run under `--release` in CI.

### CI
- Added Codecov coverage workflow.
- Cached dependencies, bumped action versions.

### Docs
- Added Codecov badges and crate metadata for crates.io.
- Fixed two README typos.